### PR TITLE
fix: writers type for block

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type SupportedNetworkName = 'mainnet-alpha' | 'goerli-alpha';
  * interacting with them in the databas.
  *e
  */
-type CheckpointWriter = (args: {
+export type CheckpointWriter = (args: {
   tx: Transaction;
   block: GetBlockResponse;
   receipt: TransactionReceipt;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Transaction, TransactionReceipt } from 'starknet';
+import { Transaction, TransactionReceipt, GetBlockResponse } from 'starknet';
 import { AsyncMySqlPool } from './mysql';
 import { LogLevel } from './utils/logger';
 
@@ -65,7 +65,7 @@ export type SupportedNetworkName = 'mainnet-alpha' | 'goerli-alpha';
  */
 type CheckpointWriter = (args: {
   tx: Transaction;
-  block: number;
+  block: GetBlockResponse;
   receipt: TransactionReceipt;
   mysql: AsyncMySqlPool;
   source: ContractSourceConfig;


### PR DESCRIPTION
The previous release erronoeusly specified the type for Checkpoint
writers as a number when it is actually an object.

It also exports the checkpoint writer function.