### PR TITLE
feat: generate sample query in graphiql

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express-graphql": "^0.12.0",
     "graphql": "^16.5.0",
     "graphql-fields": "^2.0.3",
+    "json-to-graphql-query": "^2.2.4",
     "mysql": "^2.18.1",
     "pino": "^7.11.0",
     "starknet": "^3.7.0"
@@ -41,5 +42,8 @@
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3"
   },
-  "files": ["dist/**/*", "src/**/*"]
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ]
 }

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -80,10 +80,14 @@ export default class Checkpoint {
       }
     });
 
-    return getGraphQL(querySchema, {
-      log: this.log.child({ component: 'resolver' }),
-      mysql: this.mysql
-    });
+    return getGraphQL(
+      querySchema,
+      {
+        log: this.log.child({ component: 'resolver' }),
+        mysql: this.mysql
+      },
+      this.entityController.generateSampleQuery()
+    );
   }
 
   /**

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -13,9 +13,19 @@ import { ResolverContext } from './resolvers';
  * Creates an graphql http handler for the query passed a parameters.
  * Returned middleware can be used with express.
  */
-export default function get(query: GraphQLObjectType, context: ResolverContext) {
+export default function get(
+  query: GraphQLObjectType,
+  context: ResolverContext,
+  sampleQuery?: string
+) {
   const schema = new GraphQLSchema({ query });
-  return graphqlHTTP({ schema, context, graphiql: {} });
+  return graphqlHTTP({
+    schema,
+    context,
+    graphiql: {
+      defaultQuery: sampleQuery
+    }
+  });
 }
 
 /**

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,0 +1,52 @@
+import { GraphQLObjectType, isLeafType, isWrappingType } from 'graphql';
+import { jsonToGraphQLQuery } from 'json-to-graphql-query';
+
+/**
+ * Returns name of query for fetching single entity record
+ *
+ */
+export const singleEntityQueryName = (entity: GraphQLObjectType) => entity.name.toLowerCase();
+
+/**
+ * Returns name of query for fetching multiple entity records
+ *
+ */
+export const multiEntityQueryName = (entity: GraphQLObjectType) => `${entity.name.toLowerCase()}s`;
+
+/**
+ * Generate sample query string based on entity object fields.
+ *
+ */
+export const generateQueryForEntity = (entity: GraphQLObjectType): string => {
+  // function to recursively build fields map
+  const getObjectFields = (object: GraphQLObjectType, queryFields = {}): Record<string, any> => {
+    const objectFields = object.getFields();
+
+    Object.keys(objectFields).forEach(fieldName => {
+      const rawFieldType = objectFields[fieldName].type;
+      const fieldType = isWrappingType(rawFieldType) ? rawFieldType.ofType : rawFieldType;
+
+      if (isLeafType(fieldType)) {
+        queryFields[fieldName] = true;
+      } else {
+        const childObjectFields = {};
+        getObjectFields(fieldType as GraphQLObjectType, childObjectFields);
+        queryFields[fieldName] = childObjectFields;
+      }
+    });
+
+    return queryFields;
+  };
+
+  return jsonToGraphQLQuery(
+    {
+      query: {
+        [multiEntityQueryName(entity)]: {
+          __args: { first: 10 },
+          ...getObjectFields(entity)
+        }
+      }
+    },
+    { pretty: true }
+  );
+};

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -58,3 +58,39 @@ input WhereVote {
   name_in: [String]
 }"
 `;
+
+exports[`GqlEntityController generateSampleQuery should return correct query sample for first and only entity 1`] = `
+"
+# Welcome to Checkpoint. Try running the below example query from 
+# your defined entity.
+    
+query {
+    votes (first: 10) {
+        id
+        name
+        created_at
+    }
+}"
+`;
+
+exports[`GqlEntityController generateSampleQuery should return correct query sample for nested objects 1`] = `
+"
+# Welcome to Checkpoint. Try running the below example query from 
+# your defined entity.
+    
+query {
+    votes (first: 10) {
+        id
+        name
+        poster {
+            id
+            name
+            venue {
+                id
+                location
+            }
+        }
+        created_at
+    }
+}"
+`;

--- a/test/unit/graphql/controller.test.ts
+++ b/test/unit/graphql/controller.test.ts
@@ -56,4 +56,54 @@ type Vote {
       expect(mockMysql.queryAsync).toMatchSnapshot();
     });
   });
+
+  describe('generateSampleQuery', () => {
+    it('should return undefined when no entities are defined', () => {
+      const controller = new GqlEntityController('scalar Text');
+
+      expect(controller.generateSampleQuery()).toBeUndefined();
+    });
+
+    it.each([
+      {
+        case: 'first and only entity',
+        schema: `
+type Vote {
+  id: Int!
+  name: String
+  created_at: Int!
+}
+        `
+      },
+      {
+        case: 'nested objects',
+        // Checkpoint doesn't support relationship among entities,
+        // but this just tests to ensure the sample query works for it.
+        schema: `
+type Vote {
+  id: Int!
+  name: String
+  poster: Poster
+  created_at: Int!
+}
+
+type Poster {
+  id: Int!
+  name: String!
+  venue: Venue!
+}
+
+type Venue {
+  id: Int!
+  location: String!
+}
+        `
+      }
+    ])('should return correct query sample for $case', ({ schema }) => {
+      const controller = new GqlEntityController(schema);
+
+      expect(controller.generateSampleQuery()).not.toBeUndefined();
+      expect(controller.generateSampleQuery()).toMatchSnapshot();
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,6 +2865,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-to-graphql-query@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/json-to-graphql-query/-/json-to-graphql-query-2.2.4.tgz#ada9cfdbb9bf38589fd2661e1588d1edd0a882cc"
+  integrity sha512-vNvsOKDSlEqYCzejI1xHS9Hm738dSnG4Upy09LUGqyybZXSIIb7NydDphB/6WxW2EEVpPU4JeU/Yo63Nw9dEJg==
+
 json5@2.x, json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"


### PR DESCRIPTION
This generats an example query based on the first defined entity in the
schema argument to Checkpoint.

Resolves #24 .

> Example screenshot from checkpoint-template.

<img width="1338" alt="Screenshot 2022-06-06 at 12 04 48 am" src="https://user-images.githubusercontent.com/3120013/172074377-59ed97ac-02f0-43fa-b0c7-90d300e74c85.png">

