### PR TITLE
feat: configure starknet provider url

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -41,7 +41,12 @@ export default class Checkpoint {
     this.writer = writer;
     this.schema = schema;
     this.entityController = new GqlEntityController(schema);
-    this.provider = new Provider({ network: this.config.network as SupportedNetworkName });
+
+    const providerConfig = this.config.networkBaseUrl
+      ? { baseUrl: this.config.networkBaseUrl }
+      : { network: this.config.network as SupportedNetworkName };
+    this.provider = new Provider(providerConfig);
+
     this.sourceContracts = getContractsFromConfig(config);
     this.cpBlocksCache = [];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,11 @@ export interface ContractSourceConfig {
 
 // Configuration used to initialize Checkpoint
 export interface CheckpointConfig {
-  network: SupportedNetworkName | string;
+  // mainnet-alpha or goerli-alpha network. If not interested
+  // in using the default starknet provider urls, then
+  // leave this undefined and use the networkBaseUrl
+  network?: SupportedNetworkName | string;
+  networkBaseUrl?: string;
   sources: ContractSourceConfig[];
 }
 


### PR DESCRIPTION
This updates the checkpoint configuration options to include a base url
as opposed to just specifying the network name. This will allow more
flexibility and options for StarkNet data providers.

Resolves #8 