### PR TITLE
fix: make sortBy fields a graphql enum

### DIFF
--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -34,12 +34,17 @@ CREATE TABLE votes (
 exports[`GqlEntityController generateQueryFields should work 1`] = `
 "type Query {
   vote(id: Int!): Vote
-  votes(first: Int, skip: Int, orderBy: String, orderDirection: OrderDirection, where: WhereVote): [Vote]
+  votes(first: Int, skip: Int, orderBy: OrderByVoteFields, orderDirection: OrderDirection, where: WhereVote): [Vote]
 }
 
 type Vote {
   id: Int!
   name: String
+}
+
+enum OrderByVoteFields {
+  id
+  name
 }
 
 enum OrderDirection {


### PR DESCRIPTION
This makes the sortBy fields for multi record queries to be generated as
enums. This will also help fix a potential sql injection issues that
allows users to insert arbitrary orderBy strings in queries.

Resolves #9 

<img width="1634" alt="Screenshot 2022-06-06 at 9 43 37 pm" src="https://user-images.githubusercontent.com/3120013/172257437-f009d7bd-993c-4b9a-99b0-94cc763f03da.png">
