### PR TITLE
fix: enable synchronous logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "json-to-graphql-query": "^2.2.4",
     "mysql": "^2.18.1",
     "pino": "^8.0.0",
+    "pino-pretty": "^7.6.1",
     "starknet": "^3.7.0"
   },
   "devDependencies": {
@@ -36,7 +37,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
     "jest-mock-extended": "^2.0.6",
-    "pino-pretty": "^7.6.1",
     "prettier": "^2.6.1",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.8.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface CheckpointOptions {
   // Note, this does not affect the log outputs in writers.
   logLevel?: LogLevel;
   // optionally format logs to pretty output.
-  // will require installing pino-pretty. Not recommended for production.
+  // Not recommended for production.
   prettifyLogs?: boolean;
   // Optional database connection string. For now only accepts mysql database
   // connection string. If no provided will default to looking up a value in

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -19,8 +19,13 @@ export enum LogLevel {
 
 type Logger = Omit<PinoLogger, 'trace'>;
 
-export const createLogger = (opts?: LoggerOptions): Logger => {
-  return pino(opts);
+export const createLogger = (opts: LoggerOptions = {}): Logger => {
+  return pino(
+    opts,
+    pino.destination({
+      sync: true
+    })
+  );
 };
 
 // re-export types as it is.


### PR DESCRIPTION
This enables synchronous logging for pino, which will ensure that log
outputs are not buffered but output instantly. This will help reduce
confusion when the writer functions are using the default console logger
or some other synchronous logger of their choice.

Resolves #60 

Also includes fix: enable pretty logging without dependency
This enables pretty logging without explicitly requiring the users of
the library to install pino-pretty.
