### PR TITLE
Add new config tx_fn to catch any tx

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -1,4 +1,4 @@
-name: Build, Test and Release
+name: Build, test and release
 on: [push]
 jobs:
   build-test:

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -166,7 +166,7 @@ export default class Checkpoint {
     if (this.config.tx_fn) {
       if (this.config.start) start = this.config.start;
     } else {
-      this.config.sources.forEach(source => {
+      (this.config.sources || []).forEach(source => {
         start = start === 0 || start > source.start ? source.start : start;
       });
     }
@@ -254,7 +254,7 @@ export default class Checkpoint {
     if (this.config.tx_fn)
       await this.writer[this.config.tx_fn]({ block, tx, receipt, mysql: this.mysql });
 
-    for (const source of this.config.sources) {
+    for (const source of this.config.sources || []) {
       let foundContractData = false;
       const contract = validateAndParseAddress(source.contract);
 

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -42,8 +42,8 @@ export default class Checkpoint {
     this.schema = schema;
     this.entityController = new GqlEntityController(schema);
 
-    const providerConfig = this.config.networkBaseUrl
-      ? { baseUrl: this.config.networkBaseUrl }
+    const providerConfig = this.config.network_base_url
+      ? { baseUrl: this.config.network_base_url }
       : { network: this.config.network as SupportedNetworkName };
     this.provider = new Provider(providerConfig);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export interface CheckpointConfig {
   // leave this undefined and use the network_base_url
   network?: SupportedNetworkName | string;
   network_base_url?: string;
+  start?: number;
+  tx_fn?: string;
   sources: ContractSourceConfig[];
 }
 
@@ -72,7 +74,7 @@ export type CheckpointWriter = (args: {
   block: GetBlockResponse;
   receipt: TransactionReceipt;
   mysql: AsyncMySqlPool;
-  source: ContractSourceConfig;
+  source?: ContractSourceConfig;
 }) => Promise<void>;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface CheckpointConfig {
   network_base_url?: string;
   start?: number;
   tx_fn?: string;
-  sources: ContractSourceConfig[];
+  sources?: ContractSourceConfig[];
 }
 
 export type SupportedNetworkName = 'mainnet-alpha' | 'goerli-alpha';

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,9 +36,9 @@ export interface ContractSourceConfig {
 export interface CheckpointConfig {
   // mainnet-alpha or goerli-alpha network. If not interested
   // in using the default starknet provider urls, then
-  // leave this undefined and use the networkBaseUrl
+  // leave this undefined and use the network_base_url
   network?: SupportedNetworkName | string;
-  networkBaseUrl?: string;
+  network_base_url?: string;
   sources: ContractSourceConfig[];
 }
 

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -1,5 +1,5 @@
 import { CheckpointConfig } from '../types';
 
 export const getContractsFromConfig = (config: CheckpointConfig): string[] => {
-  return config.sources.map(source => source.contract);
+  return (config.sources || []).map(source => source.contract);
 };


### PR DESCRIPTION
This add a 2 new params for the config file `tx_fn` and `start`. Using `tx_fn` allow you to trigger a writer function for all the transactions, `start` define where to start to trigger `tx_fn` writer. Here is an example of config:

```json
{
  "network": "goerli-alpha",
  "start": 276000,
  "tx_fn": "handleTx",
  "sources": []
}
```
In the writer
```ts
export async function handleTx({ block, tx, receipt, mysql }) {
  // Do stuff
}
```

Closes #62 