### PR TITLE
choosing the node one wants to use for indexing rather than use default ones only

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mysql": "^2.18.1",
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",
-    "starknet": "^3.7.0"
+    "starknet": "^4.3.0"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -42,8 +42,8 @@ export default class Checkpoint {
     this.schema = schema;
     this.entityController = new GqlEntityController(schema);
 
-    const providerConfig = this.config.network_base_url
-      ? { baseUrl: this.config.network_base_url }
+    const providerConfig = this.config.provider_config
+      ? this.config.provider_config
       : { network: this.config.network as SupportedNetworkName };
     this.provider = new Provider(providerConfig);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface CheckpointConfig {
   // in using the default starknet provider urls, then
   // leave this undefined and use the network_base_url
   network?: SupportedNetworkName | string;
-  network_base_url?: string;
+  provider_config?: object;
   start?: number;
   tx_fn?: string;
   sources?: ContractSourceConfig[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,8 @@ export interface ContractSourceConfig {
 export interface CheckpointConfig {
   // mainnet-alpha or goerli-alpha network. If not interested
   // in using the default starknet provider urls, then
-  // leave this undefined and use the network_base_url
+  // leave this undefined and use the provider_config as a
+  // classic starknet ProviderOptions object
   network?: SupportedNetworkName | string;
   provider_config?: object;
   start?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3658,9 +3658,9 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-starknet@^3.7.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/starknet/-/starknet-3.9.0.tgz#ee7a3d99effef0998b365d95dd85f9b01cdb463c"
+starknet@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-4.3.0.tgz#ee7a3d99effef0998b365d95dd85f9b01cdb463c"
   integrity sha512-/sn3WHFX7f+A3vVf3I+Kamg2KIW6494vpCcZWA09IQ5RZXrozjaBtYWT41SoKKWZ3b0Xg8WF//SOkRVCTZOZkQ==
   dependencies:
     "@ledgerhq/hw-app-eth" "^6.26.0"


### PR DESCRIPTION
this version of checkpoint allows to choose the node one wants to use for indexing starknet data rather than having to use default ones
for this network_base_url in CheckpointConfig has been replaced by provider_config which is a simple starknet ProviderOptions object ({ baseUrl: URL } for a sequencer node, { rpc: { nodeUrl: URL }} for an rpc node, etc)