### PR TITLE
feat: add support for lists

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -170,7 +170,7 @@ export class GqlEntityController {
           sql += ',';
         }
 
-        if (sqlType !== 'TEXT') {
+        if (!['TEXT', 'JSON'].includes(sqlType)) {
           sqlIndexes += `,\n  INDEX ${field.name} (${field.name})`;
         }
       });
@@ -370,7 +370,9 @@ export class GqlEntityController {
       return 'TEXT';
     }
 
-    // TODO(perfectmak): Add support for List types
+    if (type instanceof GraphQLList) {
+      return 'JSON';
+    }
 
     throw new Error(`sql type for ${type} not support`);
   }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,3 +1,4 @@
+import { GraphQLField, GraphQLList, GraphQLObjectType } from 'graphql';
 import { AsyncMySqlPool } from '../mysql';
 import { Logger } from '../utils/logger';
 
@@ -10,6 +11,8 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
   const params: any = [];
   let whereSql = '';
+
+  const jsonFields = getJsonFields(info.returnType.ofType as GraphQLObjectType);
 
   if (args.where) {
     Object.entries(args.where).map(w => {
@@ -55,15 +58,34 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
   const query = `SELECT * FROM ${info.fieldName} ${whereSql} ${orderBySql} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');
 
-  return await mysql.queryAsync(query, params);
+  const result = await mysql.queryAsync(query, params);
+  return result.map(item => formatItem(item, jsonFields));
 }
 
 export async function querySingle(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
+  const jsonFields = getJsonFields(info.returnType as GraphQLObjectType);
+
   const query = `SELECT * FROM ${info.fieldName}s WHERE id = ? LIMIT 1`;
   log.debug({ sql: query, args }, 'executing single query');
 
   const [item] = await mysql.queryAsync(query, [args.id]);
-  return item;
+  return formatItem(item, jsonFields);
+}
+
+function getJsonFields(type: GraphQLObjectType) {
+  return Object.values(type.getFields()).filter(field => field.type instanceof GraphQLList);
+}
+
+function formatItem(item: Record<string, any>, jsonFields: GraphQLField<any, any>[]) {
+  const formatted = { ...item };
+
+  jsonFields.forEach(field => {
+    if (formatted[field.name]) {
+      formatted[field.name] = JSON.parse(formatted[field.name]);
+    }
+  });
+
+  return formatted;
 }

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -16,6 +16,7 @@ DROP TABLE IF EXISTS votes;
 CREATE TABLE votes (
   id INT(128) NOT NULL,
   name VARCHAR(128),
+  authenticators JSON,
   PRIMARY KEY (id) ,
   INDEX id (id),
   INDEX name (name)
@@ -40,6 +41,7 @@ exports[`GqlEntityController generateQueryFields should work 1`] = `
 type Vote {
   id: Int!
   name: String
+  authenticators: [String]
 }
 
 enum OrderByVoteFields {

--- a/test/unit/graphql/controller.test.ts
+++ b/test/unit/graphql/controller.test.ts
@@ -10,6 +10,7 @@ describe('GqlEntityController', () => {
 type Vote {
   id: Int!
   name: String
+  authenticators: [String]
 }
   `);
       const queryFields = controller.generateQueryFields();
@@ -49,6 +50,7 @@ type Vote {
 type Vote {
   id: Int!
   name: String
+  authenticators: [String]
 }
   `);
       await controller.createEntityStores(mockMysql);


### PR DESCRIPTION
Adds support for GraphQL list. Those are represented using `JSON` column type. Those are not indexed and can't be used in `where` for now.

## Test plan

- Test using sx-api PR: https://github.com/snapshot-labs/sx-api/pull/150