### PR TITLE
feat: add support for subqueries (one-to-one)

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -137,9 +137,7 @@ export class GqlEntityController {
       entities[obj.name] = this.getTypeFields(obj).reduce((resolvers, field) => {
         if (!(field.type instanceof GraphQLObjectType)) return resolvers;
 
-        const fieldName = singleEntityQueryName(field.type);
-
-        resolvers[fieldName] = fields[fieldName].resolve;
+        resolvers[field.name] = fields[singleEntityQueryName(field.type)].resolve;
         return resolvers;
       }, {});
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -277,7 +277,21 @@ export class GqlEntityController {
     this.getTypeFields(type).forEach(field => {
       // all field types in a where input variable must be optional
       // so we try to extract the non null type here.
-      const nonNullFieldType = this.getNonNullType(field.type);
+      let nonNullFieldType = this.getNonNullType(field.type);
+
+      if (nonNullFieldType instanceof GraphQLObjectType) {
+        const fields = type.getFields();
+        const idField = fields['id'];
+
+        if (
+          idField &&
+          idField.type instanceof GraphQLNonNull &&
+          idField.type.ofType instanceof GraphQLScalarType &&
+          idField.type.ofType.name === 'String'
+        ) {
+          nonNullFieldType = this.getNonNullType(idField.type);
+        }
+      }
 
       // avoid setting up where filters for non scalar types
       if (!isLeafType(nonNullFieldType)) {

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -13,12 +13,7 @@ import { ResolverContext } from './resolvers';
  * Creates an graphql http handler for the query passed a parameters.
  * Returned middleware can be used with express.
  */
-export default function get(
-  query: GraphQLObjectType,
-  context: ResolverContext,
-  sampleQuery?: string
-) {
-  const schema = new GraphQLSchema({ query });
+export default function get(schema: GraphQLSchema, context: ResolverContext, sampleQuery?: string) {
   return graphqlHTTP({
     schema,
     context,

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -70,7 +70,8 @@ export async function querySingle(parent, args, context: ResolverContext, info) 
   const query = `SELECT * FROM ${info.fieldName}s WHERE id = ? LIMIT 1`;
   log.debug({ sql: query, args }, 'executing single query');
 
-  const [item] = await mysql.queryAsync(query, [args.id]);
+  const id = parent?.[info.fieldName] || args.id;
+  const [item] = await mysql.queryAsync(query, [id]);
   return formatItem(item, jsonFields);
 }
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -12,7 +12,8 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
   const params: any = [];
   let whereSql = '';
 
-  const jsonFields = getJsonFields(info.returnType.ofType as GraphQLObjectType);
+  const returnType = info.returnType.ofType as GraphQLObjectType;
+  const jsonFields = getJsonFields(returnType);
 
   if (args.where) {
     Object.entries(args.where).map(w => {
@@ -55,7 +56,7 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 
   params.push(skip, first);
 
-  const query = `SELECT * FROM ${info.fieldName} ${whereSql} ${orderBySql} LIMIT ?, ?`;
+  const query = `SELECT * FROM ${returnType.name.toLowerCase()}s ${whereSql} ${orderBySql} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');
 
   const result = await mysql.queryAsync(query, params);
@@ -65,9 +66,10 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 export async function querySingle(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
-  const jsonFields = getJsonFields(info.returnType as GraphQLObjectType);
+  const returnType = info.returnType as GraphQLObjectType;
+  const jsonFields = getJsonFields(returnType);
 
-  const query = `SELECT * FROM ${info.fieldName}s WHERE id = ? LIMIT 1`;
+  const query = `SELECT * FROM ${returnType.name.toLowerCase()}s WHERE id = ? LIMIT 1`;
   log.debug({ sql: query, args }, 'executing single query');
 
   const id = parent?.[info.fieldName] || args.id;


### PR DESCRIPTION
Adds support for subqueries.

## Test plan

Apply this patch to `sx-api`:
```diff
diff --git a/src/schema.gql b/src/schema.gql
index e9026b1..ecd4a93 100644
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -24,7 +24,7 @@ type Space {
 type Proposal {
   id: String!
   proposal_id: Int
-  space: String
+  space: Space
   author: String
   execution_hash: String
   metadata_uri: String
```

Run this query:
```gql
{
  proposals(first: 10) {
    id
    proposal_id
    space {
      id
      name
    }
  }
  space (id: "0x00b60f2a154b9aaec8e4bec8e04f86d6cd92a9c993871e904bd815962603492d") {
    id
    name
  }
}
```