### PR TITLE
feat: allow built-in ID type as object id

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -409,7 +409,7 @@ export class GqlEntityController {
         idField &&
         idField.type instanceof GraphQLNonNull &&
         idField.type.ofType instanceof GraphQLScalarType &&
-        idField.type.ofType.name === 'String'
+        ['String', 'ID'].includes(idField.type.ofType.name)
       ) {
         return 'VARCHAR(128)';
       }


### PR DESCRIPTION
Right now we require `id` to be String!, but it makes sense (and is common) to use `ID!`.