### PR TITLE
feat: unwrap nonNull

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,5 +1,6 @@
 import { GraphQLField, GraphQLList, GraphQLObjectType } from 'graphql';
 import { AsyncMySqlPool } from '../mysql';
+import { getNonNullType } from '../utils/graphql';
 import { Logger } from '../utils/logger';
 
 export interface ResolverContext {
@@ -66,7 +67,7 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 export async function querySingle(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
-  const returnType = info.returnType as GraphQLObjectType;
+  const returnType = getNonNullType(info.returnType) as GraphQLObjectType;
   const jsonFields = getJsonFields(returnType);
 
   const query = `SELECT * FROM ${returnType.name.toLowerCase()}s WHERE id = ? LIMIT 1`;

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,4 +1,10 @@
-import { GraphQLObjectType, isLeafType, isWrappingType } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLNonNull,
+  isLeafType,
+  isWrappingType
+} from 'graphql';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 
 /**
@@ -49,4 +55,12 @@ export const generateQueryForEntity = (entity: GraphQLObjectType): string => {
     },
     { pretty: true }
   );
+};
+
+export const getNonNullType = (type: GraphQLOutputType): GraphQLOutputType => {
+  if (type instanceof GraphQLNonNull) {
+    return type.ofType;
+  }
+
+  return type;
 };


### PR DESCRIPTION
If you make nested entity non nullable it will be wrapped in GraphQLNonNull so we need to unwrap it when using it.

## Test plan

- Change `author: User` to `author: User!` in sx-api's Proposal schema.
- Run query below.

```gql
{
  proposals(where: {space: "0x00847ae39833c61fe964bfac857ad8c5fa261ec4c716c61b8f28c4ae61fe376b"}) {
    id
    title
    author {
      id
      vote_count
    }
  }
}
```