### PR TITLE
feat: add support for BigInt and decimal types

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -41,7 +41,7 @@ export default class Checkpoint {
     this.config = config;
     this.writer = writer;
     this.schema = schema;
-    this.entityController = new GqlEntityController(schema);
+    this.entityController = new GqlEntityController(schema, opts);
 
     const providerConfig = this.config.network_base_url
       ? { baseUrl: this.config.network_base_url }

--- a/src/mysql.ts
+++ b/src/mysql.ts
@@ -44,7 +44,9 @@ export const createMySqlPool = (connection?: string): AsyncMySqlPool => {
     host: connectionConfig.hosts[0].name,
     port: connectionConfig.hosts[0].port,
     connectTimeout: 30000, // 30 seconds
-    charset: 'utf8mb4'
+    charset: 'utf8mb4',
+    supportBigNumbers: true,
+    bigNumberStrings: true
   };
 
   return mysql.createPool(config) as AsyncMySqlPool;

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -151,6 +151,6 @@ export class CheckpointsStore {
 
     this.log.debug({ result, block, contracts }, 'next checkpoint blocks');
 
-    return result.map(value => value[Fields.Checkpoints.BlockNumber]);
+    return result.map(value => Number(value[Fields.Checkpoints.BlockNumber]));
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,9 @@ export interface CheckpointOptions {
   // connection string. If no provided will default to looking up a value in
   // the DATABASE_URL environment.
   dbConnection?: string;
+  // Configuration for decimal types
+  // defaults to Decimal(10, 2), BigDecimal(20, 8)
+  decimalTypes?: { [key: string]: { p: number; d: number } };
 }
 
 export interface ContractEventConfig {

--- a/test/unit/__snapshots__/mysql.test.ts.snap
+++ b/test/unit/__snapshots__/mysql.test.ts.snap
@@ -7,6 +7,7 @@ exports[`createMySqlPool() should use argument string to create connection 1`] =
   "calls": Array [
     Array [
       Object {
+        "bigNumberStrings": true,
         "charset": "utf8mb4",
         "connectTimeout": 30000,
         "connectionLimit": 1,
@@ -15,6 +16,7 @@ exports[`createMySqlPool() should use argument string to create connection 1`] =
         "multipleStatements": true,
         "password": "pass",
         "port": 3306,
+        "supportBigNumbers": true,
         "user": "root",
       },
     ],
@@ -33,6 +35,7 @@ exports[`createMySqlPool() should use environment variables to create connection
   "calls": Array [
     Array [
       Object {
+        "bigNumberStrings": true,
         "charset": "utf8mb4",
         "connectTimeout": 30000,
         "connectionLimit": 1,
@@ -41,6 +44,7 @@ exports[`createMySqlPool() should use environment variables to create connection
         "multipleStatements": true,
         "password": "pass",
         "port": 3306,
+        "supportBigNumbers": true,
         "user": "root",
       },
     ],

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -17,9 +17,15 @@ CREATE TABLE votes (
   id INT(128) NOT NULL,
   name VARCHAR(128),
   authenticators JSON,
+  big_number BIGINT,
+  decimal DECIMAL(10, 2),
+  big_decimal DECIMAL(20, 8),
   PRIMARY KEY (id) ,
   INDEX id (id),
-  INDEX name (name)
+  INDEX name (name),
+  INDEX big_number (big_number),
+  INDEX decimal (decimal),
+  INDEX big_decimal (big_decimal)
 );",
     ],
   ],

--- a/test/unit/graphql/controller.test.ts
+++ b/test/unit/graphql/controller.test.ts
@@ -47,10 +47,17 @@ type Vote {
     it('should work', async () => {
       const mockMysql = mock<AsyncMySqlPool>();
       const controller = new GqlEntityController(`
+scalar BigInt
+scalar Decimal
+scalar BigDecimal
+
 type Vote {
   id: Int!
   name: String
   authenticators: [String]
+  big_number: BigInt
+  decimal: Decimal
+  big_decimal: BigDecimal
 }
   `);
       await controller.createEntityStores(mockMysql);


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/checkpoint/issues/152

This PR adds support for `BigInt` and decimal types (`Decimal` and `BigDecimal`).
Current mappings are:
- `BigInt` -> `BIGINT`
- `Decimal` -> `DECIMAL(10, 2)`
- `BigDecimal` -> `DECIMAL(20, 8)`.

Decimal types are configurable so you can provide different precision/decimals values (or add more variants):
```js
const checkpoint = new Checkpoint(config, writer, schema, {
  decimalTypes: {
    Decimal: {
      p: 14,
      d: 10
    },
    BigDecimal: {
      p: 20,
      d: 8
    },
    EvenBiggerDecimal: {
      p: 40,
      d: 16
    }
  }
});
```

## Usage

In your schema declare types that you use (either default ones, or the ones you added) and use those in your types as needed
```gql
scalar BigInt
scalar Decimal
scalar BigDecimal

type User {
  votes_count: BigInt
}  
```

When writing data pass your data in format `mysql` package supports (Number/String/BigInt), making sure you are not losing precision on-write.

GraphQL will return those values as string, you can query those values with where filter as with `Int` type (gt/gte/lt/lte etc. are supported), but you should use strings there to make sure precision is not lost.