### PR TITLE
feat: add templates support

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -8,6 +8,7 @@ import { GqlEntityController } from './graphql/controller';
 import { createLogger, Logger, LogLevel } from './utils/logger';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
 import {
+  ContractSourceConfig,
   Block,
   FullBlock,
   Transaction,
@@ -31,11 +32,11 @@ export default class Checkpoint {
 
   private readonly entityController: GqlEntityController;
   private readonly log: Logger;
-  private readonly sourceContracts: string[];
 
   private mysqlPool?: AsyncMySqlPool;
   private mysqlConnection?: string;
   private checkpointsStore?: CheckpointsStore;
+  private sourceContracts: string[];
   private cpBlocksCache: number[] | null;
 
   constructor(
@@ -140,6 +141,13 @@ export default class Checkpoint {
     await this.store.setMetadata(MetadataId.LastIndexedBlock, 0);
 
     await this.entityController.createEntityStores(this.mysql);
+  }
+
+  public addSource(source: ContractSourceConfig) {
+    if (!this.config.sources) this.config.sources = [];
+
+    this.config.sources.push(source);
+    this.sourceContracts = getContractsFromConfig(this.config);
   }
 
   /**
@@ -296,7 +304,7 @@ export default class Checkpoint {
     this.log.debug({ txIndex }, 'handling transaction');
 
     if (this.config.tx_fn) {
-      await this.writer[this.config.tx_fn]({ block, tx, mysql: this.mysql });
+      await this.writer[this.config.tx_fn]({ block, tx, mysql: this.mysql, instance: this });
     }
 
     for (const source of this.config.sources || []) {
@@ -314,7 +322,13 @@ export default class Checkpoint {
           'found deployment transaction'
         );
 
-        await this.writer[source.deploy_fn]({ source, block, tx, mysql: this.mysql });
+        await this.writer[source.deploy_fn]({
+          source,
+          block,
+          tx,
+          mysql: this.mysql,
+          instance: this
+        });
       }
 
       for (const event of events) {
@@ -332,7 +346,8 @@ export default class Checkpoint {
                 block,
                 tx,
                 event,
-                mysql: this.mysql
+                mysql: this.mysql,
+                instance: this
               });
             }
           }

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -148,6 +148,7 @@ export default class Checkpoint {
 
     this.config.sources.push(source);
     this.sourceContracts = getContractsFromConfig(this.config);
+    this.cpBlocksCache = [];
   }
 
   /**

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -151,6 +151,21 @@ export default class Checkpoint {
     this.cpBlocksCache = [];
   }
 
+  public executeTemplate(name: string, { contract, start }: { contract: string; start: number }) {
+    const template = this.config.templates?.[name];
+
+    if (!template) {
+      this.log.warn({ name }, 'template not found');
+      return;
+    }
+
+    this.addSource({
+      contract,
+      start,
+      events: template.events
+    });
+  }
+
   /**
    * Registers the blocks where a contracts event can be found.
    * This will be used as a skip list for checkpoints while

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { AsyncMySqlPool } from './mysql';
 import { LogLevel } from './utils/logger';
 import type { api } from 'starknet';
+import type Checkpoint from './checkpoint';
 
 // Shortcuts to starknet types.
 export type Block = api.RPC.GetBlockWithTxs;
@@ -83,6 +84,7 @@ export type CheckpointWriter = (args: {
   event?: Event;
   source?: ContractSourceConfig;
   mysql: AsyncMySqlPool;
+  instance: Checkpoint;
 }) => Promise<void>;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,12 +47,17 @@ export interface ContractSourceConfig {
   events: ContractEventConfig[];
 }
 
+export type ContractTemplate = {
+  events: ContractEventConfig[];
+};
+
 // Configuration used to initialize Checkpoint
 export interface CheckpointConfig {
   network_node_url: string;
   start?: number;
   tx_fn?: string;
   sources?: ContractSourceConfig[];
+  templates?: { [key: string]: ContractTemplate };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR allows consumers to modify sources on the fly, when other events arrive.
Writers now receive `instance` argument, which is Checkpoint instance itself. In this case developers can use `executeTemplate` to use predefined template from config.

Closes: https://github.com/snapshot-labs/checkpoint/issues/52

## Test plan

Update sx-api config to:
```json
{
  "network_node_url": "RPC",
  "sources": [
    {
      "contract": "0x2121c175922cef8870b6b6b956d01a7ac75af034dfbb9135698f88644b17ea3",
      "start": 345862,
      "events": [
        {
          "name": "space_deployed",
          "fn": "handleSpaceCreated"
        }
      ]
    }
  ],
  "templates": {
    "Space": {
      "events": [
        {
          "name": "proposal_created",
          "fn": "handlePropose"
        },
        {
          "name": "vote_created",
          "fn": "handleVote"
        }
      ]
    }
  }
}
```

Call this function in `handleSpaceCreated`:
```js
instance.executeTemplate('Space', {
  contract: item.id,
  start: block.block_number
});
```