### PR TITLE
feat: use dataloader to batch single entity queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@graphql-tools/schema": "^8.5.1",
     "bluebird": "^3.7.2",
     "connection-string": "^4.3.5",
+    "dataloader": "^2.1.0",
     "dotenv": "^16.0.1",
     "eslint": "^8.21.0",
     "express-graphql": "^0.12.0",
@@ -41,5 +42,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
-  "files": ["dist/**/*", "src/**/*"]
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,6 +1562,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dataloader@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
+
 dateformat@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"


### PR DESCRIPTION
## Summary

This PR adds [`dataloader`](https://github.com/graphql/dataloader) support for single queries that improves performance of nested queries. Now fetching 10 proposals with spaces nested in the query takes 2 requests instead of 20.

Closes: https://github.com/snapshot-labs/checkpoint/issues/147

## Test plan

Add console.log above `const results = await context.mysql.queryAsync(query, [ids]);`.

Run query:
```gql
{
  proposals(first: 100) {
    id
    proposal_id
    space {
      id
      name
    }
  }
}
```

Only single log should be emitted.