### PR TITLE
feat: escape column names

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -199,7 +199,7 @@ export class GqlEntityController {
       this.getTypeFields(type).forEach(field => {
         const sqlType = this.getSqlType(field.type);
 
-        sql += `\n  ${field.name} ${sqlType}`;
+        sql += `\n  \`${field.name}\` ${sqlType}`;
         if (field.type instanceof GraphQLNonNull) {
           sql += ' NOT NULL,';
         } else {
@@ -207,7 +207,7 @@ export class GqlEntityController {
         }
 
         if (!['TEXT', 'JSON'].includes(sqlType)) {
-          sqlIndexes += `,\n  INDEX ${field.name} (${field.name})`;
+          sqlIndexes += `,\n  INDEX \`${field.name}\` (\`${field.name}\`)`;
         }
       });
       sql += `\n  PRIMARY KEY (id) ${sqlIndexes}\n);\n`;

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -27,27 +27,27 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
       let param = w[1];
 
       if (w[0].endsWith('_not')) {
-        whereSql += `${w[0].slice(0, -4)} != ?`;
+        whereSql += `\`${w[0].slice(0, -4)}\` != ?`;
       } else if (w[0].endsWith('_gt')) {
-        whereSql += `${w[0].slice(0, -3)} > ?`;
+        whereSql += `\`${w[0].slice(0, -3)}\` > ?`;
       } else if (w[0].endsWith('_gte')) {
-        whereSql += `${w[0].slice(0, -4)} >= ?`;
+        whereSql += `\`${w[0].slice(0, -4)}\` >= ?`;
       } else if (w[0].endsWith('_lt')) {
-        whereSql += `${w[0].slice(0, -3)} < ?`;
+        whereSql += `\`${w[0].slice(0, -3)}\` < ?`;
       } else if (w[0].endsWith('_lte')) {
-        whereSql += `${w[0].slice(0, -4)} <= ?`;
+        whereSql += `\`${w[0].slice(0, -4)}\` <= ?`;
       } else if (w[0].endsWith('_not_contains')) {
-        whereSql += `${w[0].slice(0, -13)} NOT LIKE ?`;
+        whereSql += `\`${w[0].slice(0, -13)}\` NOT LIKE ?`;
         param = `%${w[1]}%`;
       } else if (w[0].endsWith('_contains')) {
-        whereSql += `${w[0].slice(0, -9)} LIKE ?`;
+        whereSql += `\`${w[0].slice(0, -9)}\` LIKE ?`;
         param = `%${w[1]}%`;
       } else if (w[0].endsWith('_not_in')) {
-        whereSql += `${w[0].slice(0, -7)} NOT IN (?)`;
+        whereSql += `\`${w[0].slice(0, -7)}\` NOT IN (?)`;
       } else if (w[0].endsWith('_in')) {
-        whereSql += `${w[0].slice(0, -3)} IN (?)`;
+        whereSql += `\`${w[0].slice(0, -3)}\` IN (?)`;
       } else {
-        whereSql += `${w[0]} = ?`;
+        whereSql += `\`${w[0]}\` = ?`;
       }
       params.push(param);
     });

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -14,18 +14,18 @@ exports[`GqlEntityController createEntityStores should work 1`] = `
 
 DROP TABLE IF EXISTS votes;
 CREATE TABLE votes (
-  id INT(128) NOT NULL,
-  name VARCHAR(128),
-  authenticators JSON,
-  big_number BIGINT,
-  decimal DECIMAL(10, 2),
-  big_decimal DECIMAL(20, 8),
+  \`id\` INT(128) NOT NULL,
+  \`name\` VARCHAR(128),
+  \`authenticators\` JSON,
+  \`big_number\` BIGINT,
+  \`decimal\` DECIMAL(10, 2),
+  \`big_decimal\` DECIMAL(20, 8),
   PRIMARY KEY (id) ,
-  INDEX id (id),
-  INDEX name (name),
-  INDEX big_number (big_number),
-  INDEX decimal (decimal),
-  INDEX big_decimal (big_decimal)
+  INDEX \`id\` (\`id\`),
+  INDEX \`name\` (\`name\`),
+  INDEX \`big_number\` (\`big_number\`),
+  INDEX \`decimal\` (\`decimal\`),
+  INDEX \`big_decimal\` (\`big_decimal\`)
 );",
     ],
   ],


### PR DESCRIPTION
## Summary

Escape column names in queries so reserved keywords can be used as columns.

Depends on https://github.com/snapshot-labs/checkpoint/pull/159

## Test plan

Apply this diff in sx-api
```diff
diff --git a/src/schema.gql b/src/schema.gql
index 978b787..49d5ff5 100644
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -25,7 +25,7 @@ type Proposal {
   id: String!
   proposal_id: Int
   space: Space
-  author: User
+  from: User
   execution_hash: String
   metadata_uri: String
   title: Text
diff --git a/src/writer.ts b/src/writer.ts
index ab167a9..e79e085 100644
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -74,7 +74,7 @@ export async function handlePropose({ block, tx, event, mysql }) {
     id: `${space}/${proposal}`,
     proposal_id: proposal,
     space,
-    author,
+    from: author,
     execution_hash: data.execution_hash,
     metadata_uri: metadataUri,
     title,
```

Run this query:
```gql
{
  proposals(where: {from: "0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A71"}) {
    id
    from {
      id
    }
  }
}
```