### PR TITLE
chore: narrow down writer's block param

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export interface CheckpointConfig {
  */
 export type CheckpointWriter = (args: {
   tx: Transaction;
-  block: Block;
+  block: FullBlock;
   event?: Event;
   source?: ContractSourceConfig;
   mysql: AsyncMySqlPool;


### PR DESCRIPTION
## Summary

We check that block has to be full block before calling writers so we can narrow it down to avoid awkward handling at writer side.