### PR TITLE
feat: expose schema and createGetLoader

### DIFF
--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -16,7 +16,7 @@ import { ResolverContextInput } from './resolvers';
  * createGetLoader should be called per-request so each request has its own caching
  * and batching.
  */
-const createGetLoader = (context: ResolverContextInput) => {
+export const createGetLoader = (context: ResolverContextInput) => {
   const loaders = {};
 
   return (name: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Checkpoint from './checkpoint';
 export { LogLevel } from './utils/logger';
 export { AsyncMySqlPool } from './mysql';
+export { createGetLoader } from './graphql';
 export * from './types';
 
 export default Checkpoint;


### PR DESCRIPTION
## Summary

This allows to use checkpoint via ApolloServer (and possibly other clients).

## Test plan

Build checkpoint from this PR and copy files over (instead of linking, as GraphQL depends on instance equality which doesn't work when linked) to sx-api, setup ApolloServer there like this:
```js
import Checkpoint, { LogLevel, createGetLoader } from '@snapshot-labs/checkpoint';

import { ApolloServer } from '@apollo/server';
import { startStandaloneServer } from '@apollo/server/standalone';

// Same checkpoint initialization here as before.

async function run() {
  const server = new ApolloServer({
    schema: checkpoint.getSchema()
  });

  const { url } = await startStandaloneServer(server, {
    listen: { port: 3000 },
    context: async () => {
      const baseContext = checkpoint.getBaseContext();
      return {
        ...baseContext,
        getLoader: createGetLoader(baseContext)
      };
    }
  });

  console.log(`🚀  Server ready at: ${url}`);
}

run();
```

Run sx-api, execute sample query:
```gql
{
  proposals(first: 100) {
    id
    proposal_id
    space {
      id
      name
    }
  }
}
```

## Screenshots
![image](https://user-images.githubusercontent.com/1968722/203336154-6f1ed6b6-ae23-4eb0-9700-bd9745ad14d9.png)
