### PR TITLE
chore: bump starknet to 4.13.1 to fix Infura compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mysql": "^2.18.1",
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",
-    "starknet": "^4.12.0"
+    "starknet": "^4.13.0"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mysql": "^2.18.1",
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",
-    "starknet": "^4.13.0"
+    "starknet": "^4.13.1"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -1,6 +1,5 @@
 import { RpcProvider } from 'starknet';
-import { starknetKeccak } from 'starknet/utils/hash';
-import { validateAndParseAddress } from 'starknet/utils/address';
+import { validateAndParseAddress, hash } from 'starknet';
 import Promise from 'bluebird';
 import { addResolversToSchema } from '@graphql-tools/schema';
 import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './graphql';
@@ -354,7 +353,7 @@ export default class Checkpoint {
       for (const event of events) {
         if (contract === validateAndParseAddress(event.from_address)) {
           for (const sourceEvent of source.events) {
-            if (`0x${starknetKeccak(sourceEvent.name).toString('hex')}` === event.keys[0]) {
+            if (`0x${hash.starknetKeccak(sourceEvent.name).toString('hex')}` === event.keys[0]) {
               foundContractData = true;
               this.log.info(
                 { contract: source.contract, event: sourceEvent.name, handlerFn: sourceEvent.fn },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
 import { AsyncMySqlPool } from './mysql';
 import { LogLevel } from './utils/logger';
-import type { api } from 'starknet';
+import type { RPC } from 'starknet';
 import type Checkpoint from './checkpoint';
 
 // Shortcuts to starknet types.
-export type Block = api.RPC.GetBlockWithTxs;
-export type Transaction = api.RPC.Transaction;
-export type Event = api.RPC.GetEventsResponse['events'][number];
+export type Block = RPC.GetBlockWithTxs;
+export type Transaction = RPC.Transaction;
+export type Event = RPC.GetEventsResponse['events'][number];
 
 // (Partially) narrowed types as real types are not exported from `starknet`.
 export type FullBlock = Block & { block_number: number };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,10 +3427,10 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-starknet@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/starknet/-/starknet-4.12.0.tgz#174e16f0aee2cc7d07f4038e4e250c6db64727c4"
-  integrity sha512-ECoz+eRh99tKars7COvm7FZkPfA1ok36+e1FhL+eyn8Q5wcHPCr85Cyu6ZZBaMmE6038Gt6gHuPsGI0skj0jxw==
+starknet@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-4.13.0.tgz#f64d3a0d24cdf27c8399f485acc8c0a4ded5c77a"
+  integrity sha512-r7s9lUIEc3+0M6D0nb7voaDb5MPz5TxhkQTU+BZMAXqDynj6xWW06Och68XyUZw5bOU16ju4rhYvf4yQb48/zA==
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
     bn.js "^5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,10 +3427,10 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-starknet@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/starknet/-/starknet-4.13.0.tgz#f64d3a0d24cdf27c8399f485acc8c0a4ded5c77a"
-  integrity sha512-r7s9lUIEc3+0M6D0nb7voaDb5MPz5TxhkQTU+BZMAXqDynj6xWW06Och68XyUZw5bOU16ju4rhYvf4yQb48/zA==
+starknet@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-4.13.1.tgz#ecd4546fff9ad736b2da8ec894a06dfcfee43582"
+  integrity sha512-KrKhBE0/v/NZT7VSdMWHKXPnnB7cYuAeBA/UuIsLOSR5y3FZHCtrm0EfTXgFdDAp2/JZREl3h/lt6BDgkrkGAQ==
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
     bn.js "^5.2.1"


### PR DESCRIPTION
4.13.1 no longer hardcodes `/rpc/v0.2` as part of URL so it's compatible with Infura.