### PR TITLE
refactor: extract NetworkProvider

### DIFF
--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,0 +1,29 @@
+import type { Logger } from '../utils/logger';
+import type Checkpoint from '../checkpoint';
+import type { AsyncMySqlPool } from '../mysql';
+import type { CheckpointConfig, CheckpointWriters } from '../types';
+
+type Instance = {
+  writer: CheckpointWriters;
+  config: CheckpointConfig;
+  setLastIndexedBlock(blockNum: number);
+  insertCheckpoints(checkpoints: { blockNumber: number; contractAddress: string }[]);
+  getWriterParams(): {
+    instance: Checkpoint;
+    mysql: AsyncMySqlPool;
+  };
+};
+
+export class BaseProvider {
+  protected readonly instance: Instance;
+  protected readonly log: Logger;
+
+  constructor({ instance, log }: { instance: Instance; log: Logger }) {
+    this.instance = instance;
+    this.log = log;
+  }
+
+  processBlock(blockNum: number) {
+    throw new Error(`processBlock method was not defined when fetching block ${blockNum}`);
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './starknet';

--- a/src/providers/starknet.ts
+++ b/src/providers/starknet.ts
@@ -1,0 +1,153 @@
+import { RpcProvider, hash, validateAndParseAddress } from 'starknet';
+import { BaseProvider } from './base';
+import { isFullBlock, isDeployTransaction } from '../types';
+import type { Block, FullBlock, Transaction, Event, EventsMap } from '../types';
+
+export class StarknetProvider extends BaseProvider {
+  private readonly provider: RpcProvider;
+
+  constructor({ instance, log }: ConstructorParameters<typeof BaseProvider>[0]) {
+    super({ instance, log });
+
+    this.provider = new RpcProvider({
+      nodeUrl: this.instance.config.network_node_url
+    });
+  }
+
+  async processBlock(blockNum: number) {
+    let block: Block;
+    let blockEvents: EventsMap;
+    try {
+      [block, blockEvents] = await Promise.all([
+        this.provider.getBlockWithTxs(blockNum),
+        this.getEvents(blockNum)
+      ]);
+
+      if (!isFullBlock(block) || block.block_number !== blockNum) {
+        this.log.error({ blockNumber: blockNum }, 'invalid block');
+        throw new Error('invalid block');
+      }
+    } catch (e) {
+      if ((e as Error).message.includes('StarknetErrorCode.BLOCK_NOT_FOUND')) {
+        this.log.info({ blockNumber: blockNum }, 'block not found');
+      } else {
+        this.log.error({ blockNumber: blockNum, err: e }, 'getting block failed... retrying');
+      }
+
+      throw e;
+    }
+
+    await this.handleBlock(block, blockEvents);
+
+    await this.instance.setLastIndexedBlock(block.block_number);
+  }
+
+  private async handleBlock(block: FullBlock, blockEvents: EventsMap) {
+    this.log.info({ blockNumber: block.block_number }, 'handling block');
+
+    for (const [i, tx] of block.transactions.entries()) {
+      await this.handleTx(
+        block,
+        i,
+        tx,
+        tx.transaction_hash ? blockEvents[tx.transaction_hash] || [] : []
+      );
+    }
+
+    this.log.debug({ blockNumber: block.block_number }, 'handling block done');
+  }
+
+  private async handleTx(block: FullBlock, txIndex: number, tx: Transaction, events: Event[]) {
+    this.log.debug({ txIndex }, 'handling transaction');
+
+    const writerParams = this.instance.getWriterParams();
+
+    if (this.instance.config.tx_fn) {
+      await this.instance.writer[this.instance.config.tx_fn]({
+        block,
+        tx,
+        ...writerParams
+      });
+    }
+
+    for (const source of this.instance.config.sources || []) {
+      let foundContractData = false;
+      const contract = validateAndParseAddress(source.contract);
+
+      if (
+        isDeployTransaction(tx) &&
+        source.deploy_fn &&
+        contract === validateAndParseAddress(tx.contract_address)
+      ) {
+        foundContractData = true;
+        this.log.info(
+          { contract: source.contract, txType: tx.type, handlerFn: source.deploy_fn },
+          'found deployment transaction'
+        );
+
+        await this.instance.writer[source.deploy_fn]({
+          source,
+          block,
+          tx,
+          ...writerParams
+        });
+      }
+
+      for (const event of events) {
+        if (contract === validateAndParseAddress(event.from_address)) {
+          for (const sourceEvent of source.events) {
+            if (`0x${hash.starknetKeccak(sourceEvent.name).toString('hex')}` === event.keys[0]) {
+              foundContractData = true;
+              this.log.info(
+                { contract: source.contract, event: sourceEvent.name, handlerFn: sourceEvent.fn },
+                'found contract event'
+              );
+
+              await this.instance.writer[sourceEvent.fn]({
+                source,
+                block,
+                tx,
+                event,
+                ...writerParams
+              });
+            }
+          }
+        }
+      }
+
+      if (foundContractData) {
+        await this.instance.insertCheckpoints([
+          { blockNumber: block.block_number, contractAddress: source.contract }
+        ]);
+      }
+    }
+
+    this.log.debug({ txIndex }, 'handling transaction done');
+  }
+
+  private async getEvents(blockNumber: number): Promise<EventsMap> {
+    const events: Event[] = [];
+
+    let continuationToken: string | undefined;
+    do {
+      const result = await this.provider.getEvents({
+        from_block: { block_number: blockNumber },
+        to_block: { block_number: blockNumber },
+        chunk_size: 1000,
+        continuation_token: continuationToken
+      });
+
+      events.push(...result.events);
+
+      continuationToken = result.continuation_token;
+    } while (continuationToken);
+
+    return events.reduce((acc, event) => {
+      if (!acc[event.transaction_hash]) acc[event.transaction_hash] = [];
+
+      acc[event.transaction_hash].push(event);
+
+      return acc;
+    }, {});
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { AsyncMySqlPool } from './mysql';
 import { LogLevel } from './utils/logger';
 import type { RPC } from 'starknet';
 import type Checkpoint from './checkpoint';
+import type { BaseProvider } from './providers';
 
 // Shortcuts to starknet types.
 export type Block = RPC.GetBlockWithTxs;
@@ -28,6 +29,8 @@ export interface CheckpointOptions {
   // Configuration for decimal types
   // defaults to Decimal(10, 2), BigDecimal(20, 8)
   decimalTypes?: { [key: string]: { p: number; d: number } };
+  // BaseProvider based class that defines how blocks are fetched and processed.
+  NetworkProvider?: typeof BaseProvider;
 }
 
 export interface ContractEventConfig {


### PR DESCRIPTION
## Summary

This PR moves Starknet logic out of Checkpoint class into `NetworkProvider` that becomes responsible for fetching blocks and processing them. This allows for replacing indexing logic if needed.

I'm not sure if it's enough of abstraction to implement what we want, because I'm not sure how custom DB would work ("custom db (would be used for Snapshot)" from issue description. Would that query data by blockNum as well or it needs higher abstraction - if it does, some details would be helpful for context.

Closes https://github.com/snapshot-labs/checkpoint/issues/155

## Test plan

- Start `sx-api`.