### PR TITLE
feat: use pluralize for better pluralization

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mysql": "^2.18.1",
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",
+    "pluralize": "^8.0.0",
     "starknet": "^4.13.1"
   },
   "devDependencies": {

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -20,6 +20,7 @@ import {
   isLeafType,
   Source
 } from 'graphql';
+import pluralize from 'pluralize';
 import { AsyncMySqlPool } from '../mysql';
 import {
   generateQueryForEntity,
@@ -192,8 +193,10 @@ export class GqlEntityController {
 
     let sql = '';
     this.schemaObjects.forEach(type => {
-      sql += `\n\nDROP TABLE IF EXISTS ${type.name.toLowerCase()}s;`;
-      sql += `\nCREATE TABLE ${type.name.toLowerCase()}s (`;
+      const tableName = pluralize(pluralize(type.name.toLowerCase()));
+
+      sql += `\n\nDROP TABLE IF EXISTS ${tableName};`;
+      sql += `\nCREATE TABLE ${tableName} (`;
       let sqlIndexes = ``;
 
       this.getTypeFields(type).forEach(field => {

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -8,6 +8,7 @@ import {
   GraphQLString
 } from 'graphql';
 import DataLoader from 'dataloader';
+import pluralize from 'pluralize';
 import { ResolverContextInput } from './resolvers';
 
 /**
@@ -22,7 +23,7 @@ export const createGetLoader = (context: ResolverContextInput) => {
   return (name: string) => {
     if (!loaders[name]) {
       loaders[name] = new DataLoader(async ids => {
-        const query = `SELECT * FROM ${name}s WHERE id in (?)`;
+        const query = `SELECT * FROM ${pluralize(name)} WHERE id in (?)`;
 
         context.log.debug({ sql: query, ids }, 'executing batched query');
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -3,6 +3,7 @@ import {
   parseResolveInfo,
   simplifyParsedResolveInfoFragmentWithType
 } from 'graphql-parse-resolve-info';
+import pluralize from 'pluralize';
 import { AsyncMySqlPool } from '../mysql';
 import { getNonNullType } from '../utils/graphql';
 import { Logger } from '../utils/logger';
@@ -66,7 +67,9 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 
   params.push(skip, first);
 
-  const query = `SELECT * FROM ${returnType.name.toLowerCase()}s ${whereSql} ${orderBySql} LIMIT ?, ?`;
+  const query = `SELECT * FROM ${pluralize(
+    returnType.name.toLowerCase()
+  )} ${whereSql} ${orderBySql} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');
 
   const result = await mysql.queryAsync(query, params);

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -6,6 +6,7 @@ import {
   isWrappingType
 } from 'graphql';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
+import pluralize from 'pluralize';
 
 /**
  * Returns name of query for fetching single entity record
@@ -17,7 +18,8 @@ export const singleEntityQueryName = (entity: GraphQLObjectType) => entity.name.
  * Returns name of query for fetching multiple entity records
  *
  */
-export const multiEntityQueryName = (entity: GraphQLObjectType) => `${entity.name.toLowerCase()}s`;
+export const multiEntityQueryName = (entity: GraphQLObjectType) =>
+  pluralize(entity.name.toLowerCase());
 
 /**
  * Generate sample query string based on entity object fields.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,6 +3171,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/checkpoint/issues/170

Uses `pluralize` to improve naive way of pluralizing queries/table names.

## Test plan

- In checkpoint-template rename `Post` to `Activity`. In writer changes `posts` to `activities` in SQL query.
- Start indexer.
- Run this query:
```gql
{
  activities {
    id
  }
}
```