### PR TITLE
feat: add globalEvents tracking

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -208,7 +208,7 @@ export default class Checkpoint {
 
     const nextBlock = lastBlock + 1;
 
-    if (this.config.tx_fn) {
+    if (this.config.tx_fn || this.config.globalEvents) {
       if (this.config.start) start = this.config.start;
     } else {
       (this.config.sources || []).forEach(source => {
@@ -219,7 +219,7 @@ export default class Checkpoint {
   }
 
   private async next(blockNum: number) {
-    if (!this.config.tx_fn) {
+    if (!this.config.tx_fn && !this.config.globalEvents) {
       const checkpointBlock = await this.getNextCheckpointBlock(blockNum);
       if (checkpointBlock) blockNum = checkpointBlock;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface CheckpointConfig {
   network_node_url: string;
   start?: number;
   tx_fn?: string;
+  globalEvents?: ContractEventConfig[];
   sources?: ContractSourceConfig[];
   templates?: { [key: string]: ContractTemplate };
 }
@@ -96,6 +97,7 @@ export type CheckpointWriter = (args: {
   block: FullBlock;
   event?: ParsedEvent;
   rawEvent?: Event;
+  eventIndex?: number;
   source?: ContractSourceConfig;
   mysql: AsyncMySqlPool;
   instance: Checkpoint;


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/checkpoint/issues/179

This PR adds support for `globalEvents` that allows you to track specific event from all contracts.

## Test plan

Link this PR to checkpoint-template branch that tracks ERC20s Transfers:
https://github.com/snapshot-labs/checkpoint-template/tree/sekhmet/erc20

Run it and run this query:
```gql
{
  transfers {
    id
    token
    from
    to
    value,
    created_at
    created_at_block
  }
}
```
<img src="https://user-images.githubusercontent.com/1968722/212327388-2ea54213-6629-4136-abba-1194a8e9c441.png" width="600" />