### PR TITLE
feat: add support for optimistic indexing

### DIFF
--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -14,6 +14,13 @@ type Instance = {
   };
 };
 
+export class BlockNotFoundError extends Error {
+  constructor() {
+    super('Block not found');
+    this.name = 'BlockNotFoundError';
+  }
+}
+
 export class BaseProvider {
   protected readonly instance: Instance;
   protected readonly log: Logger;
@@ -37,5 +44,11 @@ export class BaseProvider {
 
   processBlock(blockNum: number) {
     throw new Error(`processBlock method was not defined when fetching block ${blockNum}`);
+  }
+
+  processPool(blockNumber: number) {
+    throw new Error(
+      `processPool method was not defined when fetching pool for block ${blockNumber}`
+    );
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import type { BaseProvider } from './providers';
 // Shortcuts to starknet types.
 export type Block = RPC.GetBlockWithTxs;
 export type Transaction = RPC.Transaction;
+export type PendingTransaction = RPC.PendingTransactions[number];
 export type Event = RPC.GetEventsResponse['events'][number];
 
 // (Partially) narrowed types as real types are not exported from `starknet`.
@@ -64,6 +65,7 @@ export type ContractTemplate = {
 // Configuration used to initialize Checkpoint
 export interface CheckpointConfig {
   network_node_url: string;
+  optimistic_indexing?: boolean;
   start?: number;
   tx_fn?: string;
   global_events?: ContractEventConfig[];
@@ -96,7 +98,8 @@ export interface CheckpointConfig {
  */
 export type CheckpointWriter = (args: {
   tx: Transaction;
-  block: FullBlock;
+  block: FullBlock | null;
+  blockNumber: number;
   event?: ParsedEvent;
   rawEvent?: Event;
   eventIndex?: number;
@@ -120,6 +123,6 @@ export function isFullBlock(block: Block): block is FullBlock {
   return 'block_number' in block;
 }
 
-export function isDeployTransaction(tx: Transaction): tx is DeployTransaction {
+export function isDeployTransaction(tx: Transaction | PendingTransaction): tx is DeployTransaction {
   return tx.type === 'DEPLOY';
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/checkpoint/issues/151

This PR adds support for optimistic indexing - now pending transactions are include when indexing. This option can be enabled with `optimistic_indexing` flag.

Assumptions:
- Writer will be called only once, either from pool or block, so writer needs to handle both scenarios if optimistic indexing is enabled.
- Pending transactions will be included in the next block (not +2 block)
- Pending transaction will always be included in the next block (can't fail/revert/disappear).

## Test plan

You can use this branch to test with: https://github.com/snapshot-labs/sx-api/tree/sekhmet/optimistic (remember to link this PR's checkpoint).
Not much difference is visible on goerli2 as it takes a while for transactions to show up in pending and block times are not that bad.