### PR TITLE
feat: add subentities support

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -39,8 +39,9 @@ export default class Checkpoint {
   ) {
     this.config = config;
     this.writer = writer;
-    this.schema = schema;
-    this.entityController = new GqlEntityController(schema, opts);
+    this.schema = this.extendSchema(schema);
+
+    this.entityController = new GqlEntityController(this.schema, opts);
 
     this.sourceContracts = getContractsFromConfig(config);
     this.cpBlocksCache = [];
@@ -279,5 +280,10 @@ export default class Checkpoint {
 
     // lazy initialization of mysql connection
     return (this.mysqlPool = createMySqlPool(this.mysqlConnection));
+  }
+
+  private extendSchema(schema: string): string {
+    return `directive @derivedFrom(field: String!) on FIELD_DEFINITION
+${schema}`;
   }
 }

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -3,7 +3,8 @@ import {
   GraphQLOutputType,
   GraphQLNonNull,
   isLeafType,
-  isWrappingType
+  isListType,
+  GraphQLScalarType
 } from 'graphql';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import pluralize from 'pluralize';
@@ -32,10 +33,14 @@ export const generateQueryForEntity = (entity: GraphQLObjectType): string => {
 
     Object.keys(objectFields).forEach(fieldName => {
       const rawFieldType = objectFields[fieldName].type;
-      const fieldType = isWrappingType(rawFieldType) ? rawFieldType.ofType : rawFieldType;
+      const fieldType = rawFieldType instanceof GraphQLNonNull ? rawFieldType.ofType : rawFieldType;
 
       if (isLeafType(fieldType)) {
         queryFields[fieldName] = true;
+      } else if (isListType(fieldType)) {
+        if (fieldType.ofType instanceof GraphQLScalarType) {
+          queryFields[fieldName] = true;
+        }
       } else {
         const childObjectFields = {};
         getObjectFields(fieldType as GraphQLObjectType, childObjectFields);


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/checkpoint/issues/166

This PR adds `@derivedFrom` directive support that can be used to create 1-n queries.

## Test plan

Add a field on some entity that references other entity for example:
```gql
type Space {
  id: String!
  proposals: [Proposal]! @derivedFrom(field: "space")
}

type Proposal {
  id: String!
  space: Space
}
```

This will cause `proposals` to become available as part of Space schema resulting in this query to database (table name is derived from type used, column name is the field argument from directive):
```sql
SELECT * FROM proposals WHERE space IN (space.id)
```

Now such queries can be used:
```gql
{
  spaces {
    id
    proposals {
      id
      tx
      title
      strategies
    }
  }
}
```

You can test it against this branch on sx-api (extra changes due to event parsing): https://github.com/snapshot-labs/sx-api/tree/sekhmet/subentities