### PR TITLE
feat: allow ABI to be specified in templates

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -158,6 +158,7 @@ export default class Checkpoint {
     this.addSource({
       contract,
       start,
+      abi: template.abi,
       events: template.events
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,8 @@ export interface ContractSourceConfig {
 }
 
 export type ContractTemplate = {
+  // abi name
+  abi?: string;
   events: ContractEventConfig[];
 };
 


### PR DESCRIPTION
This way we can use automatic parsing of events for template-initiated contracts.

## Test plan

Can be tested with https://github.com/snapshot-labs/sx-api/pull/163