### PR TITLE
refactor: rename globalEvents to global_events

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -209,7 +209,7 @@ export default class Checkpoint {
 
     const nextBlock = lastBlock + 1;
 
-    if (this.config.tx_fn || this.config.globalEvents) {
+    if (this.config.tx_fn || this.config.global_events) {
       if (this.config.start) start = this.config.start;
     } else {
       (this.config.sources || []).forEach(source => {
@@ -220,7 +220,7 @@ export default class Checkpoint {
   }
 
   private async next(blockNum: number) {
-    if (!this.config.tx_fn && !this.config.globalEvents) {
+    if (!this.config.tx_fn && !this.config.global_events) {
       const checkpointBlock = await this.getNextCheckpointBlock(blockNum);
       if (checkpointBlock) blockNum = checkpointBlock;
     }

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -72,8 +72,8 @@ export class StarknetProvider extends BaseProvider {
       });
     }
 
-    if (this.instance.config.globalEvents) {
-      const globalEventHandlers = this.instance.config.globalEvents.reduce((handlers, event) => {
+    if (this.instance.config.global_events) {
+      const globalEventHandlers = this.instance.config.global_events.reduce((handlers, event) => {
         handlers[`0x${hash.starknetKeccak(event.name).toString('hex')}`] = {
           name: event.name,
           fn: event.fn

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface CheckpointConfig {
   network_node_url: string;
   start?: number;
   tx_fn?: string;
-  globalEvents?: ContractEventConfig[];
+  global_events?: ContractEventConfig[];
   sources?: ContractSourceConfig[];
   templates?: { [key: string]: ContractTemplate };
 }


### PR DESCRIPTION
## Summary

Renaming `globalEvents` to `global_events` to match other config options.