### PR TITLE
fix: pass local index when passing nested structs

### DIFF
--- a/src/providers/starknet/utils.ts
+++ b/src/providers/starknet/utils.ts
@@ -16,7 +16,7 @@ export const parseStruct = (
 
   return struct.members.reduce((output, field) => {
     if (structs[field.type]) {
-      output[field.name] = parseStruct(field.type, data, { current, structs });
+      output[field.name] = parseStruct(field.type, data, { current: structCurrent, structs });
       structCurrent += structs[field.type].size;
 
       return output;

--- a/test/unit/providers/starknet/__snapshots__/utils.test.ts.snap
+++ b/test/unit/providers/starknet/__snapshots__/utils.test.ts.snap
@@ -47,3 +47,19 @@ Object {
   "voting_strategy_params_flat_len": "0x5",
 }
 `;
+
+exports[`utils parseEvent should parse nested event 1`] = `
+Object {
+  "proposal_id": "0xf",
+  "vote": Object {
+    "choice": "0x1",
+    "voting_power": Object {
+      "high": "0x0",
+      "low": "0x23cdb7dc255bf4da",
+    },
+  },
+  "voter_address": Object {
+    "value": "0xef8305e140ac520225daf050e2f71d5fbcc543e7",
+  },
+}
+`;

--- a/test/unit/providers/starknet/fixtures.ts
+++ b/test/unit/providers/starknet/fixtures.ts
@@ -31,6 +31,14 @@ export const spaceDeployedEventData = [
   '0x0'
 ];
 
+export const voteCreatedEventData = [
+  '0xf',
+  '0xef8305e140ac520225daf050e2f71d5fbcc543e7',
+  '0x1',
+  '0x23cdb7dc255bf4da',
+  '0x0'
+];
+
 export const spaceFactoryAbi = [
   {
     name: 'Uint256',
@@ -209,6 +217,943 @@ export const spaceFactoryAbi = [
       },
       {
         name: 'metadata_uri',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  }
+];
+
+export const spaceAbi = [
+  {
+    name: 'Address',
+    size: 1,
+    type: 'struct',
+    members: [
+      {
+        name: 'value',
+        type: 'felt',
+        offset: 0
+      }
+    ]
+  },
+  {
+    name: 'Proposal',
+    size: 5,
+    type: 'struct',
+    members: [
+      {
+        name: 'quorum',
+        type: 'Uint256',
+        offset: 0
+      },
+      {
+        name: 'timestamps',
+        type: 'felt',
+        offset: 2
+      },
+      {
+        name: 'execution_strategy',
+        type: 'felt',
+        offset: 3
+      },
+      {
+        name: 'execution_hash',
+        type: 'felt',
+        offset: 4
+      }
+    ]
+  },
+  {
+    name: 'Uint256',
+    size: 2,
+    type: 'struct',
+    members: [
+      {
+        name: 'low',
+        type: 'felt',
+        offset: 0
+      },
+      {
+        name: 'high',
+        type: 'felt',
+        offset: 1
+      }
+    ]
+  },
+  {
+    name: 'Vote',
+    size: 3,
+    type: 'struct',
+    members: [
+      {
+        name: 'choice',
+        type: 'felt',
+        offset: 0
+      },
+      {
+        name: 'voting_power',
+        type: 'Uint256',
+        offset: 1
+      }
+    ]
+  },
+  {
+    name: 'AccountCallArray',
+    size: 4,
+    type: 'struct',
+    members: [
+      {
+        name: 'to',
+        type: 'felt',
+        offset: 0
+      },
+      {
+        name: 'selector',
+        type: 'felt',
+        offset: 1
+      },
+      {
+        name: 'data_offset',
+        type: 'felt',
+        offset: 2
+      },
+      {
+        name: 'data_len',
+        type: 'felt',
+        offset: 3
+      }
+    ]
+  },
+  {
+    name: 'ProposalInfo',
+    size: 11,
+    type: 'struct',
+    members: [
+      {
+        name: 'proposal',
+        type: 'Proposal',
+        offset: 0
+      },
+      {
+        name: 'power_for',
+        type: 'Uint256',
+        offset: 5
+      },
+      {
+        name: 'power_against',
+        type: 'Uint256',
+        offset: 7
+      },
+      {
+        name: 'power_abstain',
+        type: 'Uint256',
+        offset: 9
+      }
+    ]
+  },
+  {
+    data: [
+      {
+        name: 'previousOwner',
+        type: 'felt'
+      },
+      {
+        name: 'newOwner',
+        type: 'felt'
+      }
+    ],
+    keys: [],
+    name: 'OwnershipTransferred',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      },
+      {
+        name: 'proposer_address',
+        type: 'Address'
+      },
+      {
+        name: 'proposal',
+        type: 'Proposal'
+      },
+      {
+        name: 'metadata_uri_len',
+        type: 'felt'
+      },
+      {
+        name: 'metadata_uri',
+        type: 'felt*'
+      },
+      {
+        name: 'execution_params_len',
+        type: 'felt'
+      },
+      {
+        name: 'execution_params',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'proposal_created',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      },
+      {
+        name: 'voter_address',
+        type: 'Address'
+      },
+      {
+        name: 'vote',
+        type: 'Vote'
+      }
+    ],
+    keys: [],
+    name: 'vote_created',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'previous',
+        type: 'Uint256'
+      },
+      {
+        name: 'new_quorum',
+        type: 'Uint256'
+      }
+    ],
+    keys: [],
+    name: 'quorum_updated',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'previous',
+        type: 'felt'
+      },
+      {
+        name: 'new_voting_delay',
+        type: 'felt'
+      }
+    ],
+    keys: [],
+    name: 'voting_delay_updated',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'previous',
+        type: 'felt'
+      },
+      {
+        name: 'new_voting_duration',
+        type: 'felt'
+      }
+    ],
+    keys: [],
+    name: 'min_voting_duration_updated',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'previous',
+        type: 'felt'
+      },
+      {
+        name: 'new_voting_duration',
+        type: 'felt'
+      }
+    ],
+    keys: [],
+    name: 'max_voting_duration_updated',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'previous',
+        type: 'Uint256'
+      },
+      {
+        name: 'new_proposal_threshold',
+        type: 'Uint256'
+      }
+    ],
+    keys: [],
+    name: 'proposal_threshold_updated',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'new_metadata_uri_len',
+        type: 'felt'
+      },
+      {
+        name: 'new_metadata_uri',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'metadata_uri_updated',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'added_len',
+        type: 'felt'
+      },
+      {
+        name: 'added',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'authenticators_added',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'removed_len',
+        type: 'felt'
+      },
+      {
+        name: 'removed',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'authenticators_removed',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'added_len',
+        type: 'felt'
+      },
+      {
+        name: 'added',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'execution_strategies_added',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'removed_len',
+        type: 'felt'
+      },
+      {
+        name: 'removed',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'execution_strategies_removed',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'added_len',
+        type: 'felt'
+      },
+      {
+        name: 'added',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'voting_strategies_added',
+    type: 'event'
+  },
+  {
+    data: [
+      {
+        name: 'removed_len',
+        type: 'felt'
+      },
+      {
+        name: 'removed',
+        type: 'felt*'
+      }
+    ],
+    keys: [],
+    name: 'voting_strategies_removed',
+    type: 'event'
+  },
+  {
+    name: 'constructor',
+    type: 'constructor',
+    inputs: [
+      {
+        name: 'public_key',
+        type: 'felt'
+      },
+      {
+        name: 'voting_delay',
+        type: 'felt'
+      },
+      {
+        name: 'min_voting_duration',
+        type: 'felt'
+      },
+      {
+        name: 'max_voting_duration',
+        type: 'felt'
+      },
+      {
+        name: 'proposal_threshold',
+        type: 'Uint256'
+      },
+      {
+        name: 'controller',
+        type: 'felt'
+      },
+      {
+        name: 'quorum',
+        type: 'Uint256'
+      },
+      {
+        name: 'voting_strategies_len',
+        type: 'felt'
+      },
+      {
+        name: 'voting_strategies',
+        type: 'felt*'
+      },
+      {
+        name: 'voting_strategy_params_flat_len',
+        type: 'felt'
+      },
+      {
+        name: 'voting_strategy_params_flat',
+        type: 'felt*'
+      },
+      {
+        name: 'authenticators_len',
+        type: 'felt'
+      },
+      {
+        name: 'authenticators',
+        type: 'felt*'
+      },
+      {
+        name: 'execution_strategies_len',
+        type: 'felt'
+      },
+      {
+        name: 'execution_strategies',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'getPublicKey',
+    type: 'function',
+    inputs: [],
+    outputs: [
+      {
+        name: 'publicKey',
+        type: 'felt'
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    name: 'supportsInterface',
+    type: 'function',
+    inputs: [
+      {
+        name: 'interfaceId',
+        type: 'felt'
+      }
+    ],
+    outputs: [
+      {
+        name: 'success',
+        type: 'felt'
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    name: 'setPublicKey',
+    type: 'function',
+    inputs: [
+      {
+        name: 'newPublicKey',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'isValidSignature',
+    type: 'function',
+    inputs: [
+      {
+        name: 'hash',
+        type: 'felt'
+      },
+      {
+        name: 'signature_len',
+        type: 'felt'
+      },
+      {
+        name: 'signature',
+        type: 'felt*'
+      }
+    ],
+    outputs: [
+      {
+        name: 'isValid',
+        type: 'felt'
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    name: '__validate__',
+    type: 'function',
+    inputs: [
+      {
+        name: 'call_array_len',
+        type: 'felt'
+      },
+      {
+        name: 'call_array',
+        type: 'AccountCallArray*'
+      },
+      {
+        name: 'calldata_len',
+        type: 'felt'
+      },
+      {
+        name: 'calldata',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: '__validate_declare__',
+    type: 'function',
+    inputs: [
+      {
+        name: 'class_hash',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: '__validate_deploy__',
+    type: 'function',
+    inputs: [
+      {
+        name: 'class_hash',
+        type: 'felt'
+      },
+      {
+        name: 'salt',
+        type: 'felt'
+      },
+      {
+        name: 'publicKey',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: '__execute__',
+    type: 'function',
+    inputs: [
+      {
+        name: 'call_array_len',
+        type: 'felt'
+      },
+      {
+        name: 'call_array',
+        type: 'AccountCallArray*'
+      },
+      {
+        name: 'calldata_len',
+        type: 'felt'
+      },
+      {
+        name: 'calldata',
+        type: 'felt*'
+      }
+    ],
+    outputs: [
+      {
+        name: 'response_len',
+        type: 'felt'
+      },
+      {
+        name: 'response',
+        type: 'felt*'
+      }
+    ]
+  },
+  {
+    name: 'propose',
+    type: 'function',
+    inputs: [
+      {
+        name: 'proposer_address',
+        type: 'Address'
+      },
+      {
+        name: 'metadata_uri_string_len',
+        type: 'felt'
+      },
+      {
+        name: 'metadata_uri_len',
+        type: 'felt'
+      },
+      {
+        name: 'metadata_uri',
+        type: 'felt*'
+      },
+      {
+        name: 'execution_strategy',
+        type: 'felt'
+      },
+      {
+        name: 'used_voting_strategies_len',
+        type: 'felt'
+      },
+      {
+        name: 'used_voting_strategies',
+        type: 'felt*'
+      },
+      {
+        name: 'user_voting_strategy_params_flat_len',
+        type: 'felt'
+      },
+      {
+        name: 'user_voting_strategy_params_flat',
+        type: 'felt*'
+      },
+      {
+        name: 'execution_params_len',
+        type: 'felt'
+      },
+      {
+        name: 'execution_params',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'vote',
+    type: 'function',
+    inputs: [
+      {
+        name: 'voter_address',
+        type: 'Address'
+      },
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      },
+      {
+        name: 'choice',
+        type: 'felt'
+      },
+      {
+        name: 'used_voting_strategies_len',
+        type: 'felt'
+      },
+      {
+        name: 'used_voting_strategies',
+        type: 'felt*'
+      },
+      {
+        name: 'user_voting_strategy_params_flat_len',
+        type: 'felt'
+      },
+      {
+        name: 'user_voting_strategy_params_flat',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'finalizeProposal',
+    type: 'function',
+    inputs: [
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      },
+      {
+        name: 'execution_params_len',
+        type: 'felt'
+      },
+      {
+        name: 'execution_params',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'cancelProposal',
+    type: 'function',
+    inputs: [
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      },
+      {
+        name: 'execution_params_len',
+        type: 'felt'
+      },
+      {
+        name: 'execution_params',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'hasVoted',
+    type: 'function',
+    inputs: [
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      },
+      {
+        name: 'voter_address',
+        type: 'Address'
+      }
+    ],
+    outputs: [
+      {
+        name: 'voted',
+        type: 'felt'
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    name: 'getProposalInfo',
+    type: 'function',
+    inputs: [
+      {
+        name: 'proposal_id',
+        type: 'felt'
+      }
+    ],
+    outputs: [
+      {
+        name: 'proposal_info',
+        type: 'ProposalInfo'
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    name: 'setController',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_controller',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'setQuorum',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_quorum',
+        type: 'Uint256'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'setVotingDelay',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_delay',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'setMinVotingDuration',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_min_voting_duration',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'setMaxVotingDuration',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_max_voting_duration',
+        type: 'felt'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'setProposalThreshold',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_proposal_threshold',
+        type: 'Uint256'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'setMetadataUri',
+    type: 'function',
+    inputs: [
+      {
+        name: 'new_metadata_uri_len',
+        type: 'felt'
+      },
+      {
+        name: 'new_metadata_uri',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'addExecutionStrategies',
+    type: 'function',
+    inputs: [
+      {
+        name: 'addresses_len',
+        type: 'felt'
+      },
+      {
+        name: 'addresses',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'removeExecutionStrategies',
+    type: 'function',
+    inputs: [
+      {
+        name: 'addresses_len',
+        type: 'felt'
+      },
+      {
+        name: 'addresses',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'addVotingStrategies',
+    type: 'function',
+    inputs: [
+      {
+        name: 'addresses_len',
+        type: 'felt'
+      },
+      {
+        name: 'addresses',
+        type: 'felt*'
+      },
+      {
+        name: 'params_flat_len',
+        type: 'felt'
+      },
+      {
+        name: 'params_flat',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'removeVotingStrategies',
+    type: 'function',
+    inputs: [
+      {
+        name: 'indexes_len',
+        type: 'felt'
+      },
+      {
+        name: 'indexes',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'addAuthenticators',
+    type: 'function',
+    inputs: [
+      {
+        name: 'addresses_len',
+        type: 'felt'
+      },
+      {
+        name: 'addresses',
+        type: 'felt*'
+      }
+    ],
+    outputs: []
+  },
+  {
+    name: 'removeAuthenticators',
+    type: 'function',
+    inputs: [
+      {
+        name: 'addresses_len',
+        type: 'felt'
+      },
+      {
+        name: 'addresses',
         type: 'felt*'
       }
     ],

--- a/test/unit/providers/starknet/utils.test.ts
+++ b/test/unit/providers/starknet/utils.test.ts
@@ -1,10 +1,21 @@
 import { parseEvent } from '../../../../src/providers/starknet/utils';
-import { spaceFactoryAbi, spaceDeployedEventData } from './fixtures';
+import {
+  spaceFactoryAbi,
+  spaceAbi,
+  spaceDeployedEventData,
+  voteCreatedEventData
+} from './fixtures';
 
 describe('utils', () => {
   describe('parseEvent', () => {
     it('should parse event', () => {
       const output = parseEvent(spaceFactoryAbi, 'space_deployed', spaceDeployedEventData);
+
+      expect(output).toMatchSnapshot();
+    });
+
+    it('should parse nested event', () => {
+      const output = parseEvent(spaceAbi, 'vote_created', voteCreatedEventData);
 
       expect(output).toMatchSnapshot();
     });


### PR DESCRIPTION
## Summary

When parsing nested structs we should pass index for current index within the struct. Previously it would pass index where its parent starts.

## Test plan

Test case makes sense (it used to return `{ high: '0x0', low: '0x23cdb7dc255bf4da' }` because it was reading choice as part of Uint256.