### PR TITLE
fix: add special pluralization for metadata

### DIFF
--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -8,8 +8,8 @@ import {
   GraphQLString
 } from 'graphql';
 import DataLoader from 'dataloader';
-import pluralize from 'pluralize';
 import { ResolverContextInput } from './resolvers';
+import { getTableName } from '../utils/database';
 
 /**
  * Creates getLoader function that will return existing, or create a new dataloader
@@ -25,7 +25,7 @@ export const createGetLoader = (context: ResolverContextInput) => {
 
     if (!loaders[key]) {
       loaders[key] = new DataLoader(async ids => {
-        const query = `SELECT * FROM ${pluralize(name)} WHERE ${field} in (?)`;
+        const query = `SELECT * FROM ${getTableName(name)} WHERE ${field} in (?)`;
         context.log.debug({ sql: query, ids }, 'executing batched query');
 
         const results = await context.mysql.queryAsync(query, [ids]);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -11,9 +11,9 @@ import {
   parseResolveInfo,
   simplifyParsedResolveInfoFragmentWithType
 } from 'graphql-parse-resolve-info';
-import pluralize from 'pluralize';
 import { AsyncMySqlPool } from '../mysql';
 import { getNonNullType } from '../utils/graphql';
+import { getTableName } from '../utils/database';
 import { Logger } from '../utils/logger';
 import type DataLoader from 'dataloader';
 
@@ -75,7 +75,7 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 
   params.push(skip, first);
 
-  const query = `SELECT * FROM ${pluralize(
+  const query = `SELECT * FROM ${getTableName(
     returnType.name.toLowerCase()
   )} ${whereSql} ${orderBySql} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,0 +1,7 @@
+import pluralize from 'pluralize';
+
+export const getTableName = (name: string) => {
+  if (name === '_metadata') return '_metadatas';
+
+  return pluralize(name);
+};

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -19,8 +19,11 @@ export const singleEntityQueryName = (entity: GraphQLObjectType) => entity.name.
  * Returns name of query for fetching multiple entity records
  *
  */
-export const multiEntityQueryName = (entity: GraphQLObjectType) =>
-  pluralize(entity.name.toLowerCase());
+export const multiEntityQueryName = (entity: GraphQLObjectType) => {
+  if (entity.name === '_Metadata') return '_metadatas';
+
+  return pluralize(entity.name.toLowerCase());
+};
 
 /**
  * Generate sample query string based on entity object fields.


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/checkpoint/issues/194

This PR adds special pluralization for metadata so it becomes querable again.
Alternatively we could use default pluralization (for database, still need it for GraphQL), but it will mean that DB schema will be different.

## Test plan

Run this query:
```gql
{
  _metadatas {
    id
    value
  }
  _metadata(id: "last_indexed_block") {
    id
    value
  }
}
```