### PR TITLE
feat: log processing errors

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -242,7 +242,11 @@ export default class Checkpoint {
       if (this.config.optimistic_indexing && err instanceof BlockNotFoundError) {
         try {
           await this.networkProvider.processPool(blockNum);
-        } catch (err) {}
+        } catch (err) {
+          this.log.error({ blockNumber: blockNum, err }, 'error occured during pool processing');
+        }
+      } else {
+        this.log.error({ blockNumber: blockNum, err }, 'error occured during block processing');
       }
 
       await Promise.delay(REFRESH_INTERVAL);


### PR DESCRIPTION
Currently if errors occurs when processing blocks there is no feedback (other than seeing indexer process same block over and over).
We should log those errors so it's easy to see the issues.

## Test plan
- Test with https://github.com/snapshot-labs/sx-api/pull/177 by linking checkpoint
- Break something in the code, for example change `spaces` table name to `borked` in query to insert new proposal).
- Run `yarn dev` on sx-api.
- Errors get logged.