### PR TITLE
feat: add resetMetadata function

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -145,6 +145,19 @@ export default class Checkpoint {
     await this.entityController.createEntityStores(this.mysql);
   }
 
+  /**
+   * Resets Checkpoint's internal tables (including checkpoints).
+   *
+   * Calling this function will cause next run of checkpoint to start syncing
+   * from the start, block-by-block, until new checkpoints are found.
+   *
+   */
+  public async resetMetadata() {
+    this.log.debug('reset metadata');
+
+    await this.store.resetStore();
+  }
+
   public addSource(source: ContractSourceConfig) {
     if (!this.config.sources) this.config.sources = [];
 

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -86,6 +86,23 @@ export class CheckpointsStore {
     this.log.debug('checkpoints tables created');
   }
 
+  /**
+   * Truncates core database tables.
+   *
+   * Calling it will cause all checkpoints to be deleted and will force
+   * syncing to start from start.
+   *
+   */
+  public async resetStore(): Promise<void> {
+    this.log.debug('truncating checkpoints tables');
+
+    let sql = `TRUNCATE TABLE ${Table.Checkpoints};`;
+    sql += `TRUNCATE TABLE ${Table.Metadata};`;
+
+    await this.mysql.queryAsync(sql);
+    this.log.debug('checkpoints tables truncated');
+  }
+
   public async getMetadata(id: string): Promise<string | null> {
     const value = await this.mysql.queryAsync(
       `SELECT ${Fields.Metadata.Value} FROM ${Table.Metadata} WHERE ${Fields.Metadata.Id} = ? LIMIT 1`,


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/checkpoint/issues/197

If you end up with bad state (you added new event you want to index) there is currently no way of resetting it via checkpoint and you need to delete tables manually from SQL.

This function will handle truncating Checkpoint's metadata, it will be later used to automatically handle those cases.

## Test plan

Test with: https://github.com/snapshot-labs/sx-api/pull/177

Run 

```ts
async function run() {
  await checkpoint.reset();
  await checkpoint.resetMetadata();
  await checkpoint.start();
}

run();
```

It starts from zero.