### PR TITLE
fix: convert resetStore to use knex

### DIFF
--- a/src/knex.ts
+++ b/src/knex.ts
@@ -68,7 +68,7 @@ export function getConnectionData(connectionString: string) {
       password: connectionConfig.password,
       host: connectionConfig.hosts[0].name,
       port: connectionConfig.hosts[0].port,
-      ssl: sslConfig,
+      ssl: Object.keys(sslConfig).length > 0 ? sslConfig : undefined,
       ...EXTRA_OPTIONS[client]
     }
   };

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -106,10 +106,17 @@ export class CheckpointsStore {
   public async resetStore(): Promise<void> {
     this.log.debug('truncating checkpoints tables');
 
-    let sql = `TRUNCATE TABLE ${Table.Checkpoints};`;
-    sql += `TRUNCATE TABLE ${Table.Metadata};`;
+    const hasCheckpointsTable = await this.knex.schema.hasTable(Table.Checkpoints);
+    const hasMetadataTable = await this.knex.schema.hasTable(Table.Metadata);
 
-    await this.mysql.queryAsync(sql);
+    if (hasCheckpointsTable) {
+      await this.knex(Table.Checkpoints).truncate();
+    }
+
+    if (hasMetadataTable) {
+      await this.knex(Table.Checkpoints).truncate();
+    }
+
     this.log.debug('checkpoints tables truncated');
   }
 


### PR DESCRIPTION
Tests were actually failing for good reason, but I didn't pull latest master so I looked like CI issue.

This PR removes `mysql` usage in checkpoint's store that ended up there after merging two last PRs.