### PR TITLE
fix: only join entries from same block_range and indexer

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -174,9 +174,10 @@ export async function queryMulti(
 
         query = query
           .columns(nestedEntitiesMappings[fieldName])
-          .innerJoin(nestedTableName, `${tableName}.${fieldName}`, '=', `${nestedTableName}.id`);
+          .innerJoin(nestedTableName, `${tableName}.${fieldName}`, '=', `${nestedTableName}.id`)
+          .whereRaw('?? = ??', [`${tableName}._indexer`, `${nestedTableName}._indexer`]);
 
-        query = applyQueryFilter(query, tableName, {
+        query = applyQueryFilter(query, nestedTableName, {
           block: args.block,
           indexer: args.indexer
         });


### PR DESCRIPTION
Previously it was possible that entities from other indexer would be joined.

Following could have happened:
1. Proposal gets created on sn with some content.
2. Same proposal gets created eth with same content as 1 (same IPFS hash).
3. When requesting proposals for space on eth proposals would be duplicated if there is identical metadata on other network.

## Test plan

Either sync both `sn` and `base` or run Checkpoint with production database (make sure you comment out reset/resetMetadata/start).

Run following query:
```gql
{
  proposals(
    where: {
      cancelled: false
      space_in: ["0x21F0D41367b5Eb935f7fe91695B730cE90C80EB2"]
      metadata_: { title_contains_nocase: "" }
    }
    orderBy: id
  ) {
    id
    _indexer
  }
}
```

You don't see duplicate entries.