### PR TITLE
perf: use getBlockWithReceipts method for pool processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/strings": "^5.7.0",
     "@graphql-tools/schema": "^8.5.1",
+    "@starknet-io/types-js": "^0.7.10",
     "connection-string": "^4.3.5",
     "dataloader": "^2.1.0",
     "express-graphql": "^0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,11 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
+"@starknet-io/types-js@^0.7.10":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.10.tgz#d21dc973d0cd04d7b6293ce461f2f06a5873c760"
+  integrity sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/workflow/issues/546

This method will reduce number of requests made for processing pool in Starknet. 

It's not available in starknet.js@5. Initially I wanted to upgrade to starknet.js v6 or v7, but TypeScript types there are a mess. It was just simpler to backport this method.

## Test plan

1. Apply following diff to delegates-api.
2. Wait for it to sync up.
3. Delegate your [STRK token](https://starkscan.co/token/0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f#read-write-contract-sub-write).
4. It gets picked up.

```diff
diff --git a/src/index.ts b/src/index.ts
index 62c4a54..a437697 100644
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ async function run() {
     overridesConfig
   });
 
-  addEvmIndexers(checkpoint);
+  // addEvmIndexers(checkpoint);
   addStarknetIndexers(checkpoint);
 
   const server = new ApolloServer({
diff --git a/src/starknet/config.ts b/src/starknet/config.ts
index 9dc7083..d8648c4 100644
--- a/src/starknet/config.ts
+++ b/src/starknet/config.ts
@@ -20,14 +20,14 @@ const TOKEN_SOURCES: Record<NetworkID, Source[]> = {
       name: 'STRK',
       abi: 'Token',
       contract: '0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f',
-      start: 536311
-    },
-    {
-      name: 'NSTR',
-      abi: 'Token2',
-      contract: '0x00c530f2c0aa4c16a0806365b0898499fba372e5df7a7172dc6fe9ba777e8007',
-      start: 644053
+      start: 1564463
     }
+    // {
+    //   name: 'NSTR',
+    //   abi: 'Token2',
+    //   contract: '0x00c530f2c0aa4c16a0806365b0898499fba372e5df7a7172dc6fe9ba777e8007',
+    //   start: 644053
+    // }
   ]
 };
 
@@ -48,6 +48,7 @@ export default function createConfig(network: NetworkID) {
 
   return {
     network_node_url: NETWORK_NODE_URLS[network],
+    optimistic_indexing: true,
     sources,
     abis: { Token, Token2 }
   };
```