### PR TITLE
chore: bump graphql-parse-resolve-info

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express-graphql": "^0.12.0",
     "graphql": "^16.5.0",
     "graphql-fields": "^2.0.3",
-    "graphql-parse-resolve-info": "^4.12.3",
+    "graphql-parse-resolve-info": "^4.14.1",
     "json-to-graphql-query": "^2.2.4",
     "knex": "^3.1.0",
     "object-hash": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,10 +2560,10 @@ graphql-fields@^2.0.3:
   resolved "https://registry.yarnpkg.com/graphql-fields/-/graphql-fields-2.0.3.tgz#5e68dff7afbb202be4f4f40623e983b22c96ab8f"
   integrity sha512-x3VE5lUcR4XCOxPIqaO4CE+bTK8u6gVouOdpQX9+EKHr+scqtK5Pp/l8nIGqIpN1TUlkKE6jDCCycm/WtLRAwA==
 
-graphql-parse-resolve-info@^4.12.3:
-  version "4.12.3"
-  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.12.3.tgz#89df645f72c068760eed9176806009107b6c6ed5"
-  integrity sha512-Lxb+v+SCxzBZHKohK4xje3CBQ1iZ968DiKuFtmwzSaI45oP8FgPJjJv35TOzgv73QLijEdgH4NDZGwIvwJM7Kw==
+graphql-parse-resolve-info@^4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.14.1.tgz#7954b03d9d377849ca2cbd6f798165ad66207b63"
+  integrity sha512-WKHukfEuZamP1ZONR84b8iT+4sJgEhtXMDArm1jpXEsU2vTb5EgkCZ4Obfl+v09oNTKXm0CJjPfBUZ5jcJ2Ykg==
   dependencies:
     debug "^4.1.1"
     tslib "^2.0.1"


### PR DESCRIPTION
This version is compatible with GraphQL v16 (it already was before,
but it wasn't listed in peerDependencies).
