### PR TITLE
feat: add log message on RPC range hints

### DIFF
--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -433,6 +433,11 @@ export class EvmProvider extends BaseProvider {
         });
 
         if (rangeHint) {
+          this.log.warn(
+            { err, rangeHint, fromBlock: currentFrom, toBlock: currentTo },
+            'getLogs failed. Received new range hint'
+          );
+
           currentFrom = rangeHint.from;
           currentTo = rangeHint.to;
           continue;


### PR DESCRIPTION
I've seen some weird behavior. Possibly it could be some provider suggesting range that moves from back into the past, but we don't have logs to verify that.