### PR TITLE
perf: add partial index for current-version entity lookups

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -273,6 +273,15 @@ export class GqlEntityController {
             )
             .toQuery()
         );
+
+        builder = builder.raw(
+          knex
+            .raw(
+              'CREATE INDEX ON ?? (id, _indexer) WHERE upper_inf(block_range)',
+              [tableName]
+            )
+            .toQuery()
+        );
       }
     });
 


### PR DESCRIPTION
Auto-create a partial composite index `(id, _indexer) WHERE upper_inf(block_range)` on every entity table. Speeds up the hot-path query used by Model.loadEntity, save, and delete, and by the GraphQL DataLoader for single-entity resolution, which all filter by `id = ? AND _indexer = ? AND upper_inf(block_range)`. The partial predicate keeps the index small even as historical versions accumulate.