### PR TITLE
perf(evm): cap HyperSync preload range to 1M blocks

### DIFF
--- a/src/providers/evm/hypersync-provider.ts
+++ b/src/providers/evm/hypersync-provider.ts
@@ -41,6 +41,8 @@ type HyperSyncResponse = {
   }[];
 };
 
+const PRELOAD_RANGE = 1000000;
+
 const FIELD_SELECTION = {
   block: ['number', 'timestamp', 'hash', 'parent_hash'],
   log: [
@@ -74,7 +76,7 @@ export class HyperSyncEvmProvider extends EvmProvider {
   }
 
   getPreloadRange(): number {
-    return Infinity;
+    return PRELOAD_RANGE;
   }
 
   async getCheckpointsRange(


### PR DESCRIPTION
HyperSync's getPreloadRange returned Infinity, so each preload fetched the full (currentBlock, ~450M) tail in one call. When a new contract source was discovered mid-stream the buffer was discarded and the entire range refetched, taking 10-15 minutes per cycle. Cap the range so each preload covers at most 1M blocks, bounding throwaway work on source discovery while staying large enough to amortize per-request overhead.