### PR TITLE
feat: add state_retention_blocks to purge old historical entity rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.69",
+  "version": "0.1.0-beta.70",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/container.ts
+++ b/src/container.ts
@@ -56,6 +56,8 @@ export class Container implements Instance {
   private preloadedBlocks: number[] = [];
   private preloadEndBlock = 0;
 
+  private lastPurgeBlock: number | null = null;
+
   constructor(
     indexerName: string,
     log: Logger,
@@ -353,6 +355,18 @@ export class Container implements Instance {
         }
 
         blockNumber = nextBlockNumber;
+
+        if (this.config.state_retention_blocks) {
+          if (this.lastPurgeBlock === null) {
+            this.lastPurgeBlock = blockNumber;
+          } else if (
+            blockNumber - this.lastPurgeBlock >=
+            this.config.state_retention_blocks
+          ) {
+            await this.purgeOldState(blockNumber);
+            this.lastPurgeBlock = blockNumber;
+          }
+        }
       } catch (err) {
         if (err instanceof BlockNotFoundError) {
           if (this.config.optimistic_indexing) {
@@ -387,6 +401,28 @@ export class Container implements Instance {
 
         await sleep(this.config.fetch_interval || DEFAULT_FETCH_INTERVAL);
       }
+    }
+  }
+
+  private async purgeOldState(currentBlock: number) {
+    const retention = this.config.state_retention_blocks as number;
+    const cutoff = currentBlock - retention;
+    if (cutoff <= 0) return;
+
+    const tables = this.entityController.schemaObjects.map(entity =>
+      getTableName(entity.name.toLowerCase())
+    );
+
+    this.log.info({ cutoff, currentBlock }, 'purging old state');
+
+    for (const tableName of tables) {
+      const deleted = await this.knex
+        .table(tableName)
+        .where('_indexer', this.indexerName)
+        .andWhereRaw('upper(block_range) <= ?', [cutoff])
+        .delete();
+
+      this.log.debug({ table: tableName, deleted }, 'purged rows');
     }
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -26,7 +26,8 @@ export const checkpointConfigSchema = z.object({
   global_events: z.array(contractEventConfigSchema).optional(),
   sources: z.array(contractSourceConfigSchema).optional(),
   templates: z.record(contractTemplateSchema).optional(),
-  abis: z.record(z.any()).optional()
+  abis: z.record(z.any()).optional(),
+  state_retention_blocks: z.number().int().positive().optional()
 });
 
 export const overridesConfigSchema = z.object({


### PR DESCRIPTION
Add an opt-in `state_retention_blocks` config option. When set to N, the container periodically deletes closed-range entity rows whose entire validity window falls more than N blocks behind the synced head, and runs that purge once every N synced blocks so the cost stays amortized. Defaults to off; current rows (`upper_inf(block_range)`) are never touched. The retention value must exceed the maximum expected reorg depth or reorg recovery may lose state.