### PR TITLE
chore: exclude test files from tsc compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary
- Adds `**/*.test.ts` and `**/*.spec.ts` to the `exclude` list in `tsconfig.json`.

## Why
Colocated test files inside `src/` (e.g. `src/providers/evm/helpers.test.ts`) were being compiled into `dist/`, polluting build output. The existing `include: ["src/**/*"]` already covers `src/`, so the new `exclude` entries trim out test files specifically.

## Verification
- `rm -rf dist && yarn build` — no `*.test.js` / `*.spec.js` files in `dist/`