### PR TITLE
feat: add @computed directive and custom resolvers

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -94,7 +94,8 @@ export default class Checkpoint {
     return {
       log: this.log.child({ component: 'resolver' }),
       knex: this.knex,
-      pg: this.pg
+      pg: this.pg,
+      computedResolvers: this.opts?.resolvers
     };
   }
 

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -30,8 +30,7 @@ export default class Checkpoint {
     this.schema = extendSchema(schema);
     this.entityController = new GqlEntityController(
       this.schema,
-      opts?.overridesConfig,
-      opts?.resolvers
+      opts?.overridesConfig
     );
 
     this.opts = opts;

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -30,7 +30,8 @@ export default class Checkpoint {
     this.schema = extendSchema(schema);
     this.entityController = new GqlEntityController(
       this.schema,
-      opts?.overridesConfig
+      opts?.overridesConfig,
+      opts?.resolvers
     );
 
     this.opts = opts;

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -14,7 +14,7 @@ import {
 import pluralize from 'pluralize';
 import { GqlEntityController } from './graphql/controller';
 import { OverridesConfig } from './types';
-import { getDerivedFromDirective } from './utils/graphql';
+import { getComputedDirective, getDerivedFromDirective } from './utils/graphql';
 
 type TypeInfo = {
   type: string;
@@ -154,6 +154,8 @@ export const codegen = (
         : `  constructor(id: ${idType.baseType}, indexerName: string) {\n`;
     contents += `    super(${modelName}.tableName, indexerName);\n\n`;
     typeFields.forEach(field => {
+      if (getComputedDirective(field)) return;
+
       const fieldType =
         field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
       if (
@@ -189,6 +191,8 @@ export const codegen = (
     contents += `  }\n\n`;
 
     typeFields.forEach(field => {
+      if (getComputedDirective(field)) return;
+
       const fieldType =
         field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
       if (

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -26,10 +26,11 @@ import { Knex } from 'knex';
 import pluralize from 'pluralize';
 import { CheckpointsGraphQLObject, MetadataGraphQLObject } from '.';
 import { KnexType } from '../knex';
-import { OverridesConfig } from '../types';
+import { ComputedResolvers, OverridesConfig } from '../types';
 import { getNestedResolver, queryMulti, querySingle } from './resolvers';
 import {
   generateQueryForEntity,
+  getComputedDirective,
   getDerivedFromDirective,
   getNonNullType,
   multiEntityQueryName,
@@ -70,9 +71,14 @@ type WhereResult = {
 export class GqlEntityController {
   private readonly schema: GraphQLSchema;
   private readonly decimalTypes: NonNullable<OverridesConfig['decimal_types']>;
+  private readonly computedResolvers: ComputedResolvers;
   private _schemaObjects?: GraphQLObjectType[];
 
-  constructor(typeDefs: string | Source, config?: OverridesConfig) {
+  constructor(
+    typeDefs: string | Source,
+    config?: OverridesConfig,
+    computedResolvers?: ComputedResolvers
+  ) {
     this.schema = buildSchema(typeDefs);
     this.decimalTypes = config?.decimal_types || {
       Decimal: {
@@ -84,6 +90,7 @@ export class GqlEntityController {
         d: 8
       }
     };
+    this.computedResolvers = computedResolvers || {};
   }
 
   /**
@@ -236,6 +243,8 @@ export class GqlEntityController {
           t.specificType('block_range', 'int8range').notNullable();
 
           this.getTypeFields(type).forEach(field => {
+            if (getComputedDirective(field)) return;
+
             const fieldType =
               field.type instanceof GraphQLNonNull
                 ? field.type.ofType
@@ -381,6 +390,8 @@ export class GqlEntityController {
       };
 
       this.getTypeFields(nestedType).forEach(field => {
+        if (getComputedDirective(field)) return;
+
         // all field types in a where input variable must be optional
         // so we try to extract the non null type here.
         let nonNullFieldType = getNonNullType(field.type);
@@ -639,9 +650,23 @@ export class GqlEntityController {
     const schema = new GraphQLSchema({ query });
 
     if (opts?.addResolvers) {
+      const entityResolvers = this.generateEntityResolvers(entityQueryFields);
+
+      for (const [typeName, fields] of Object.entries(this.computedResolvers)) {
+        if (!entityResolvers[typeName]) entityResolvers[typeName] = {};
+
+        for (const [fieldName, resolver] of Object.entries(fields)) {
+          entityResolvers[typeName][fieldName] = (
+            parent: Record<string, any>,
+            args: Record<string, any>,
+            context: any
+          ) => resolver(parent, args, context);
+        }
+      }
+
       return addResolversToSchema({
         schema,
-        resolvers: this.generateEntityResolvers(entityQueryFields)
+        resolvers: entityResolvers
       });
     }
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -392,6 +392,20 @@ export class GqlEntityController {
       this.getTypeFields(nestedType).forEach(field => {
         if (getComputedDirective(field)) {
           orderByValues[field.name] = { value: field.name };
+
+          const fieldType = getNonNullType(field.type);
+          if (fieldType === GraphQLInt) {
+            for (const suffix of ['', '_not', '_gt', '_gte', '_lt', '_lte']) {
+              whereInputConfig.fields[`${field.name}${suffix}`] = {
+                type: GraphQLInt
+              };
+            }
+            for (const suffix of ['_in', '_not_in']) {
+              whereInputConfig.fields[`${field.name}${suffix}`] = {
+                type: new GraphQLList(GraphQLInt)
+              };
+            }
+          }
           return;
         }
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -658,15 +658,16 @@ export class GqlEntityController {
       for (const [typeName, fields] of Object.entries(this.computedResolvers)) {
         if (!entityResolvers[typeName]) entityResolvers[typeName] = {};
 
-        for (const [fieldName, resolver] of Object.entries(fields)) {
-          const resolveFn =
-            typeof resolver === 'function' ? resolver : resolver.resolve;
-
+        for (const [fieldName, config] of Object.entries(fields)) {
           entityResolvers[typeName][fieldName] = (
             parent: Record<string, any>,
             args: Record<string, any>,
             context: any
-          ) => resolveFn(parent, args, context);
+          ) => {
+            if (parent[fieldName] !== undefined) return parent[fieldName];
+            if (config.resolve) return config.resolve(parent, args, context);
+            return 0;
+          };
         }
       }
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -169,7 +169,7 @@ export class GqlEntityController {
 
             if (itemType instanceof GraphQLObjectType) {
               resolvers[field.name] = getNestedResolver(
-                multiEntityQueryName(itemType)
+                singleEntityQueryName(itemType)
               );
             }
           }

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -26,7 +26,7 @@ import { Knex } from 'knex';
 import pluralize from 'pluralize';
 import { CheckpointsGraphQLObject, MetadataGraphQLObject } from '.';
 import { KnexType } from '../knex';
-import { ComputedResolvers, OverridesConfig } from '../types';
+import { OverridesConfig } from '../types';
 import { getNestedResolver, queryMulti, querySingle } from './resolvers';
 import {
   generateQueryForEntity,
@@ -71,14 +71,9 @@ type WhereResult = {
 export class GqlEntityController {
   private readonly schema: GraphQLSchema;
   private readonly decimalTypes: NonNullable<OverridesConfig['decimal_types']>;
-  private readonly computedResolvers: ComputedResolvers;
   private _schemaObjects?: GraphQLObjectType[];
 
-  constructor(
-    typeDefs: string | Source,
-    config?: OverridesConfig,
-    computedResolvers?: ComputedResolvers
-  ) {
+  constructor(typeDefs: string | Source, config?: OverridesConfig) {
     this.schema = buildSchema(typeDefs);
     this.decimalTypes = config?.decimal_types || {
       Decimal: {
@@ -90,7 +85,6 @@ export class GqlEntityController {
         d: 8
       }
     };
-    this.computedResolvers = computedResolvers || {};
   }
 
   /**
@@ -390,25 +384,6 @@ export class GqlEntityController {
       };
 
       this.getTypeFields(nestedType).forEach(field => {
-        if (getComputedDirective(field)) {
-          orderByValues[field.name] = { value: field.name };
-
-          const fieldType = getNonNullType(field.type);
-          if (fieldType === GraphQLInt) {
-            for (const suffix of ['', '_not', '_gt', '_gte', '_lt', '_lte']) {
-              whereInputConfig.fields[`${field.name}${suffix}`] = {
-                type: GraphQLInt
-              };
-            }
-            for (const suffix of ['_in', '_not_in']) {
-              whereInputConfig.fields[`${field.name}${suffix}`] = {
-                type: new GraphQLList(GraphQLInt)
-              };
-            }
-          }
-          return;
-        }
-
         // all field types in a where input variable must be optional
         // so we try to extract the non null type here.
         let nonNullFieldType = getNonNullType(field.type);
@@ -667,27 +642,9 @@ export class GqlEntityController {
     const schema = new GraphQLSchema({ query });
 
     if (opts?.addResolvers) {
-      const entityResolvers = this.generateEntityResolvers(entityQueryFields);
-
-      for (const [typeName, fields] of Object.entries(this.computedResolvers)) {
-        if (!entityResolvers[typeName]) entityResolvers[typeName] = {};
-
-        for (const [fieldName, config] of Object.entries(fields)) {
-          entityResolvers[typeName][fieldName] = (
-            parent: Record<string, any>,
-            args: Record<string, any>,
-            context: any
-          ) => {
-            if (parent[fieldName] !== undefined) return parent[fieldName];
-            if (config.resolve) return config.resolve(parent, args, context);
-            return 0;
-          };
-        }
-      }
-
       return addResolversToSchema({
         schema,
-        resolvers: entityResolvers
+        resolvers: this.generateEntityResolvers(entityQueryFields)
       });
     }
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -390,7 +390,10 @@ export class GqlEntityController {
       };
 
       this.getTypeFields(nestedType).forEach(field => {
-        if (getComputedDirective(field)) return;
+        if (getComputedDirective(field)) {
+          orderByValues[field.name] = { value: field.name };
+          return;
+        }
 
         // all field types in a where input variable must be optional
         // so we try to extract the non null type here.
@@ -656,11 +659,14 @@ export class GqlEntityController {
         if (!entityResolvers[typeName]) entityResolvers[typeName] = {};
 
         for (const [fieldName, resolver] of Object.entries(fields)) {
+          const resolveFn =
+            typeof resolver === 'function' ? resolver : resolver.resolve;
+
           entityResolvers[typeName][fieldName] = (
             parent: Record<string, any>,
             args: Record<string, any>,
             context: any
-          ) => resolver(parent, args, context);
+          ) => resolveFn(parent, args, context);
         }
       }
 

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -15,6 +15,7 @@ import {
   getTableName,
   QueryFilter
 } from '../utils/database';
+import { getComputedConfigs } from '../utils/graphql';
 
 /**
  * Creates getLoader function that will return existing, or create a new dataloader
@@ -37,10 +38,8 @@ export const createGetLoader = (context: ResolverContextInput) => {
           .from(tableName)
           .whereIn(field, ids as string[]);
 
-        const computed = Object.entries(context.computedResolvers || {}).find(
-          ([typeName]) => typeName.toLowerCase() === name
-        )?.[1];
-        for (const [fieldName, config] of Object.entries(computed || {})) {
+        const computed = getComputedConfigs(context.computedResolvers, name);
+        for (const [fieldName, config] of Object.entries(computed)) {
           query = query.select(config.sql(context.knex).as(fieldName));
         }
 

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -33,9 +33,16 @@ export const createGetLoader = (context: ResolverContextInput) => {
         const tableName = getTableName(name);
 
         let query = context.knex
-          .select('*')
+          .select(`${tableName}.*`)
           .from(tableName)
           .whereIn(field, ids as string[]);
+
+        const computed = Object.entries(context.computedResolvers || {}).find(
+          ([typeName]) => typeName.toLowerCase() === name
+        )?.[1];
+        for (const [fieldName, config] of Object.entries(computed || {})) {
+          query = query.select(config.sql(context.knex).as(fieldName));
+        }
 
         query = applyQueryFilter(query, tableName, filter);
         query = applyDefaultOrder(query, tableName);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -16,6 +16,7 @@ import {
 } from 'graphql-parse-resolve-info';
 import { Knex } from 'knex';
 import { Pool as PgPool } from 'pg';
+import { ComputedResolvers } from '../types';
 import {
   applyDefaultOrder,
   applyQueryFilter,
@@ -62,6 +63,7 @@ export type ResolverContext = ResolverContextInput & {
     field: string,
     queryFilter: QueryFilter
   ) => DataLoader<readonly unknown[], any>;
+  computedResolvers?: ComputedResolvers;
 };
 
 export async function queryMulti(
@@ -82,6 +84,15 @@ export async function queryMulti(
   const nestedEntitiesMappings = {} as Record<string, Record<string, string>>;
 
   let query = knex.select(`${tableName}.*`).from(tableName);
+
+  const entityComputedResolvers =
+    context.computedResolvers?.[returnType.name] || {};
+  for (const [fieldName, resolver] of Object.entries(entityComputedResolvers)) {
+    if (typeof resolver !== 'function' && resolver.sql) {
+      query = query.select(resolver.sql(knex).as(fieldName));
+    }
+  }
+
   query = applyQueryFilter(query, tableName, {
     block: args.block,
     indexer: args.indexer
@@ -238,8 +249,15 @@ export async function queryMulti(
   }
 
   if (args.orderBy) {
+    const computedResolver =
+      entityComputedResolvers[args.orderBy];
+    const isComputedSql =
+      computedResolver &&
+      typeof computedResolver !== 'function' &&
+      computedResolver.sql;
+
     query = query.orderBy(
-      `${tableName}.${args.orderBy}`,
+      isComputedSql ? args.orderBy : `${tableName}.${args.orderBy}`,
       args.orderDirection?.toLowerCase() || 'desc'
     );
   }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -108,13 +108,13 @@ export async function queryMulti(
 
     const computedOps: Record<string, string> = {
       '': '=',
-      '_not': '!=',
-      '_gt': '>',
-      '_gte': '>=',
-      '_lt': '<',
-      '_lte': '<=',
-      '_in': 'IN',
-      '_not_in': 'NOT IN'
+      _not: '!=',
+      _gt: '>',
+      _gte: '>=',
+      _lt: '<',
+      _lte: '<=',
+      _in: 'IN',
+      _not_in: 'NOT IN'
     };
 
     Object.entries(where).map((w: [string, any]) => {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -23,7 +23,11 @@ import {
   getTableName,
   QueryFilter
 } from '../utils/database';
-import { getDerivedFromDirective, getNonNullType } from '../utils/graphql';
+import {
+  getComputedConfigs,
+  getDerivedFromDirective,
+  getNonNullType
+} from '../utils/graphql';
 import { Logger } from '../utils/logger';
 
 type BaseArgs = {
@@ -85,8 +89,10 @@ export async function queryMulti(
 
   let query = knex.select(`${tableName}.*`).from(tableName);
 
-  const entityComputedResolvers =
-    context.computedResolvers?.[returnType.name] || {};
+  const entityComputedResolvers = getComputedConfigs(
+    context.computedResolvers,
+    returnType.name
+  );
   for (const [fieldName, config] of Object.entries(entityComputedResolvers)) {
     query = query.select(config.sql(knex).as(fieldName));
   }
@@ -106,34 +112,34 @@ export async function queryMulti(
       return isListType(fieldType);
     };
 
+    const cmpOps: Record<string, string> = {
+      '': '=',
+      _not: '!=',
+      _gt: '>',
+      _gte: '>=',
+      _lt: '<',
+      _lte: '<='
+    };
+    const likeOps: Record<string, string> = {
+      _contains: 'LIKE',
+      _not_contains: 'NOT LIKE',
+      _contains_nocase: 'ILIKE',
+      _not_contains_nocase: 'NOT ILIKE'
+    };
     const buildComputedWhere = (
       sub: string,
       suffix: string,
       value: any
     ): { sql: string; bindings: any[] } | null => {
-      const ops: Record<string, string> = {
-        '': '=',
-        _not: '!=',
-        _gt: '>',
-        _gte: '>=',
-        _lt: '<',
-        _lte: '<='
-      };
-      if (suffix in ops)
-        return { sql: `${sub} ${ops[suffix]} ?`, bindings: [value] };
+      if (suffix in cmpOps)
+        return { sql: `${sub} ${cmpOps[suffix]} ?`, bindings: [value] };
+      if (suffix in likeOps)
+        return { sql: `${sub} ${likeOps[suffix]} ?`, bindings: [`%${value}%`] };
       if (suffix === '_in' || suffix === '_not_in') {
         const op = suffix === '_in' ? 'IN' : 'NOT IN';
         const placeholders = value.map(() => '?').join(', ');
         return { sql: `${sub} ${op} (${placeholders})`, bindings: value };
       }
-      if (suffix === '_contains')
-        return { sql: `${sub} LIKE ?`, bindings: [`%${value}%`] };
-      if (suffix === '_not_contains')
-        return { sql: `${sub} NOT LIKE ?`, bindings: [`%${value}%`] };
-      if (suffix === '_contains_nocase')
-        return { sql: `${sub} ILIKE ?`, bindings: [`%${value}%`] };
-      if (suffix === '_not_contains_nocase')
-        return { sql: `${sub} NOT ILIKE ?`, bindings: [`%${value}%`] };
       return null;
     };
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -87,10 +87,8 @@ export async function queryMulti(
 
   const entityComputedResolvers =
     context.computedResolvers?.[returnType.name] || {};
-  for (const [fieldName, resolver] of Object.entries(entityComputedResolvers)) {
-    if (typeof resolver !== 'function' && resolver.sql) {
-      query = query.select(resolver.sql(knex).as(fieldName));
-    }
+  for (const [fieldName, config] of Object.entries(entityComputedResolvers)) {
+    query = query.select(config.sql(knex).as(fieldName));
   }
 
   query = applyQueryFilter(query, tableName, {
@@ -249,15 +247,9 @@ export async function queryMulti(
   }
 
   if (args.orderBy) {
-    const computedResolver =
-      entityComputedResolvers[args.orderBy];
-    const isComputedSql =
-      computedResolver &&
-      typeof computedResolver !== 'function' &&
-      computedResolver.sql;
-
+    const isComputed = args.orderBy in entityComputedResolvers;
     query = query.orderBy(
-      isComputedSql ? args.orderBy : `${tableName}.${args.orderBy}`,
+      isComputed ? args.orderBy : `${tableName}.${args.orderBy}`,
       args.orderDirection?.toLowerCase() || 'desc'
     );
   }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -144,6 +144,8 @@ export async function queryMulti(
     };
 
     Object.entries(where).map((w: [string, any]) => {
+      // TODO: we could generate where as objects { name, column, operator, value }
+      // so we don't have to cut it there
       for (const [name, config] of Object.entries(entityComputedResolvers)) {
         if (!w[0].startsWith(name)) continue;
         const suffix = w[0].slice(name.length);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -394,7 +394,7 @@ export async function querySingle(
 }
 
 export const getNestedResolver =
-  (columnName: string) =>
+  (entityName: string) =>
   async (
     parent: Result,
     args: unknown,
@@ -429,7 +429,7 @@ export const getNestedResolver =
     let result: Record<string, any>[] = [];
     if (!derivedFromDirective) {
       const loaderResult = await getLoader(
-        columnName,
+        entityName,
         'id',
         queryFilter
       ).loadMany(parent[info.fieldName]);
@@ -449,7 +449,7 @@ export const getNestedResolver =
       }
 
       result = await getLoader(
-        columnName,
+        entityName,
         fieldArgument.value.value,
         queryFilter
       ).load(parent.id);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -121,25 +121,25 @@ export async function queryMulti(
       _lte: '<='
     };
     const likeOps: Record<string, string> = {
-      _contains: 'LIKE',
-      _not_contains: 'NOT LIKE',
-      _contains_nocase: 'ILIKE',
-      _not_contains_nocase: 'NOT ILIKE'
+      _contains: 'like',
+      _not_contains: 'not like',
+      _contains_nocase: 'ilike',
+      _not_contains_nocase: 'not ilike'
     };
-    const buildComputedWhere = (
-      sub: string,
+    const applyComputedWhere = (
+      currentQuery: Knex.QueryBuilder,
+      sub: Knex.QueryBuilder,
       suffix: string,
       value: any
-    ): { sql: string; bindings: any[] } | null => {
+    ): Knex.QueryBuilder | null => {
+      const expr = knex.raw('(?)', [sub]);
       if (suffix in cmpOps)
-        return { sql: `${sub} ${cmpOps[suffix]} ?`, bindings: [value] };
+        return currentQuery.where(expr, cmpOps[suffix], value);
       if (suffix in likeOps)
-        return { sql: `${sub} ${likeOps[suffix]} ?`, bindings: [`%${value}%`] };
-      if (suffix === '_in' || suffix === '_not_in') {
-        const op = suffix === '_in' ? 'IN' : 'NOT IN';
-        const placeholders = value.map(() => '?').join(', ');
-        return { sql: `${sub} ${op} (${placeholders})`, bindings: value };
-      }
+        return currentQuery.where(expr, likeOps[suffix], `%${value}%`);
+      if (suffix === '_in') return currentQuery.where(expr, 'in', value);
+      if (suffix === '_not_in')
+        return currentQuery.where(expr, 'not in', value);
       return null;
     };
 
@@ -149,13 +149,14 @@ export async function queryMulti(
       for (const [name, config] of Object.entries(entityComputedResolvers)) {
         if (!w[0].startsWith(name)) continue;
         const suffix = w[0].slice(name.length);
-        const built = buildComputedWhere(
-          `(${config.sql(knex).toQuery()})`,
+        const applied = applyComputedWhere(
+          query,
+          config.sql(knex),
           suffix,
           w[1]
         );
-        if (built) {
-          query = query.whereRaw(built.sql, built.bindings);
+        if (applied) {
+          query = applied;
           return;
         }
       }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -106,9 +106,32 @@ export async function queryMulti(
       return isListType(fieldType);
     };
 
+    const computedOps: Record<string, string> = {
+      '': '=',
+      '_not': '!=',
+      '_gt': '>',
+      '_gte': '>=',
+      '_lt': '<',
+      '_lte': '<=',
+      '_in': 'IN',
+      '_not_in': 'NOT IN'
+    };
+
     Object.entries(where).map((w: [string, any]) => {
-      // TODO: we could generate where as objects { name, column, operator, value }
-      // so we don't have to cut it there
+      for (const [name, config] of Object.entries(entityComputedResolvers)) {
+        for (const [suffix, op] of Object.entries(computedOps)) {
+          if (w[0] !== `${name}${suffix}`) continue;
+
+          const sub = `(${config.sql(knex).toQuery()})`;
+          if (op === 'IN' || op === 'NOT IN') {
+            const placeholders = w[1].map(() => '?').join(', ');
+            query = query.whereRaw(`${sub} ${op} (${placeholders})`, w[1]);
+          } else {
+            query = query.whereRaw(`${sub} ${op} ?`, [w[1]]);
+          }
+          return;
+        }
+      }
 
       if (w[0].endsWith('_not')) {
         const fieldName = w[0].slice(0, -4);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -55,6 +55,7 @@ export type ResolverContextInput = {
   log: Logger;
   knex: Knex;
   pg: PgPool;
+  computedResolvers?: ComputedResolvers;
 };
 
 export type ResolverContext = ResolverContextInput & {
@@ -63,7 +64,6 @@ export type ResolverContext = ResolverContextInput & {
     field: string,
     queryFilter: QueryFilter
   ) => DataLoader<readonly unknown[], any>;
-  computedResolvers?: ComputedResolvers;
 };
 
 export async function queryMulti(
@@ -106,29 +106,48 @@ export async function queryMulti(
       return isListType(fieldType);
     };
 
-    const computedOps: Record<string, string> = {
-      '': '=',
-      _not: '!=',
-      _gt: '>',
-      _gte: '>=',
-      _lt: '<',
-      _lte: '<=',
-      _in: 'IN',
-      _not_in: 'NOT IN'
+    const buildComputedWhere = (
+      sub: string,
+      suffix: string,
+      value: any
+    ): { sql: string; bindings: any[] } | null => {
+      const ops: Record<string, string> = {
+        '': '=',
+        _not: '!=',
+        _gt: '>',
+        _gte: '>=',
+        _lt: '<',
+        _lte: '<='
+      };
+      if (suffix in ops)
+        return { sql: `${sub} ${ops[suffix]} ?`, bindings: [value] };
+      if (suffix === '_in' || suffix === '_not_in') {
+        const op = suffix === '_in' ? 'IN' : 'NOT IN';
+        const placeholders = value.map(() => '?').join(', ');
+        return { sql: `${sub} ${op} (${placeholders})`, bindings: value };
+      }
+      if (suffix === '_contains')
+        return { sql: `${sub} LIKE ?`, bindings: [`%${value}%`] };
+      if (suffix === '_not_contains')
+        return { sql: `${sub} NOT LIKE ?`, bindings: [`%${value}%`] };
+      if (suffix === '_contains_nocase')
+        return { sql: `${sub} ILIKE ?`, bindings: [`%${value}%`] };
+      if (suffix === '_not_contains_nocase')
+        return { sql: `${sub} NOT ILIKE ?`, bindings: [`%${value}%`] };
+      return null;
     };
 
     Object.entries(where).map((w: [string, any]) => {
       for (const [name, config] of Object.entries(entityComputedResolvers)) {
-        for (const [suffix, op] of Object.entries(computedOps)) {
-          if (w[0] !== `${name}${suffix}`) continue;
-
-          const sub = `(${config.sql(knex).toQuery()})`;
-          if (op === 'IN' || op === 'NOT IN') {
-            const placeholders = w[1].map(() => '?').join(', ');
-            query = query.whereRaw(`${sub} ${op} (${placeholders})`, w[1]);
-          } else {
-            query = query.whereRaw(`${sub} ${op} ?`, [w[1]]);
-          }
+        if (!w[0].startsWith(name)) continue;
+        const suffix = w[0].slice(name.length);
+        const built = buildComputedWhere(
+          `(${config.sql(knex).toQuery()})`,
+          suffix,
+          w[1]
+        );
+        if (built) {
+          query = query.whereRaw(built.sql, built.bindings);
           return;
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,11 +15,18 @@ export type TemplateSource = {
   template: string;
 };
 
-export type ComputedFieldResolver = (
+export type ComputedFieldResolverFn = (
   parent: Record<string, any>,
   args: Record<string, any>,
   context: { knex: import('knex').Knex }
 ) => any;
+
+export type ComputedFieldConfig = {
+  resolve: ComputedFieldResolverFn;
+  sql?: (knex: import('knex').Knex) => import('knex').Knex.QueryBuilder;
+};
+
+export type ComputedFieldResolver = ComputedFieldResolverFn | ComputedFieldConfig;
 
 export type ComputedResolvers = Record<
   string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,22 +15,18 @@ export type TemplateSource = {
   template: string;
 };
 
-export type ComputedFieldResolverFn = (
-  parent: Record<string, any>,
-  args: Record<string, any>,
-  context: { knex: import('knex').Knex }
-) => any;
-
 export type ComputedFieldConfig = {
-  resolve: ComputedFieldResolverFn;
-  sql?: (knex: import('knex').Knex) => import('knex').Knex.QueryBuilder;
+  sql: (knex: import('knex').Knex) => import('knex').Knex.QueryBuilder;
+  resolve?: (
+    parent: Record<string, any>,
+    args: Record<string, any>,
+    context: { knex: import('knex').Knex }
+  ) => any;
 };
-
-export type ComputedFieldResolver = ComputedFieldResolverFn | ComputedFieldConfig;
 
 export type ComputedResolvers = Record<
   string,
-  Record<string, ComputedFieldResolver>
+  Record<string, ComputedFieldConfig>
 >;
 
 export interface CheckpointOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,17 @@ export type TemplateSource = {
   template: string;
 };
 
+export type ComputedFieldResolver = (
+  parent: Record<string, any>,
+  args: Record<string, any>,
+  context: { knex: import('knex').Knex }
+) => any;
+
+export type ComputedResolvers = Record<
+  string,
+  Record<string, ComputedFieldResolver>
+>;
+
 export interface CheckpointOptions {
   /** Setting this to true will trigger reset of database on config changes. */
   resetOnConfigChange?: boolean;
@@ -42,6 +53,11 @@ export interface CheckpointOptions {
    * This can speed up indexing process if you don't need block data.
    */
   skipBlockFetching?: boolean;
+  /**
+   * Custom resolvers for @computed fields.
+   * Format: { EntityName: { fieldName: resolverFn } }
+   */
+  resolvers?: ComputedResolvers;
 }
 
 export type ContractSourceConfig = z.infer<typeof contractSourceConfigSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Knex } from 'knex';
 import pino from 'pino';
 import { z } from 'zod';
 import { Instance } from './providers';
@@ -16,11 +17,11 @@ export type TemplateSource = {
 };
 
 export type ComputedFieldConfig = {
-  sql: (knex: import('knex').Knex) => import('knex').Knex.QueryBuilder;
+  sql: (knex: Knex) => Knex.QueryBuilder;
   resolve?: (
     parent: Record<string, any>,
     args: Record<string, any>,
-    context: { knex: import('knex').Knex }
+    context: { knex: Knex }
   ) => any;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,11 +18,6 @@ export type TemplateSource = {
 
 export type ComputedFieldConfig = {
   sql: (knex: Knex) => Knex.QueryBuilder;
-  resolve?: (
-    parent: Record<string, any>,
-    args: Record<string, any>,
-    context: { knex: Knex }
-  ) => any;
 };
 
 export type ComputedResolvers = Record<

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -17,7 +17,7 @@ export const extendSchema = (schema: string): string => {
 
   const updatedAst = visit(ast, {
     Document(node) {
-      const directiveDefinition = {
+      const derivedFromDirective = {
         kind: 'DirectiveDefinition',
         name: { kind: 'Name', value: 'derivedFrom' },
         arguments: [
@@ -36,9 +36,20 @@ export const extendSchema = (schema: string): string => {
         locations: [{ kind: 'Name', value: 'FIELD_DEFINITION' }]
       };
 
+      const computedDirective = {
+        kind: 'DirectiveDefinition',
+        name: { kind: 'Name', value: 'computed' },
+        arguments: [],
+        locations: [{ kind: 'Name', value: 'FIELD_DEFINITION' }]
+      };
+
       return {
         ...node,
-        definitions: [directiveDefinition, ...node.definitions]
+        definitions: [
+          derivedFromDirective,
+          computedDirective,
+          ...node.definitions
+        ]
       };
     },
     ObjectTypeDefinition(node) {
@@ -137,4 +148,9 @@ export const getNonNullType = <T>(type: T): T => {
 export const getDerivedFromDirective = (field: GraphQLField<any, any>) => {
   const directives = field.astNode?.directives ?? [];
   return directives.find(dir => dir.name.value === 'derivedFrom');
+};
+
+export const getComputedDirective = (field: GraphQLField<any, any>) => {
+  const directives = field.astNode?.directives ?? [];
+  return directives.find(dir => dir.name.value === 'computed');
 };

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -11,43 +11,34 @@ import {
 } from 'graphql';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import pluralize from 'pluralize';
+import { ComputedResolvers } from '../types';
+
+const directiveDef = (name: string, args: any[] = []) => ({
+  kind: 'DirectiveDefinition',
+  name: { kind: 'Name', value: name },
+  arguments: args,
+  locations: [{ kind: 'Name', value: 'FIELD_DEFINITION' }]
+});
+
+const nonNullStringArg = (name: string) => ({
+  kind: 'InputValueDefinition',
+  name: { kind: 'Name', value: name },
+  type: {
+    kind: 'NonNullType',
+    type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } }
+  }
+});
 
 export const extendSchema = (schema: string): string => {
   const ast = parse(schema);
 
   const updatedAst = visit(ast, {
     Document(node) {
-      const derivedFromDirective = {
-        kind: 'DirectiveDefinition',
-        name: { kind: 'Name', value: 'derivedFrom' },
-        arguments: [
-          {
-            kind: 'InputValueDefinition',
-            name: { kind: 'Name', value: 'field' },
-            type: {
-              kind: 'NonNullType',
-              type: {
-                kind: 'NamedType',
-                name: { kind: 'Name', value: 'String' }
-              }
-            }
-          }
-        ],
-        locations: [{ kind: 'Name', value: 'FIELD_DEFINITION' }]
-      };
-
-      const computedDirective = {
-        kind: 'DirectiveDefinition',
-        name: { kind: 'Name', value: 'computed' },
-        arguments: [],
-        locations: [{ kind: 'Name', value: 'FIELD_DEFINITION' }]
-      };
-
       return {
         ...node,
         definitions: [
-          derivedFromDirective,
-          computedDirective,
+          directiveDef('derivedFrom', [nonNullStringArg('field')]),
+          directiveDef('computed'),
           ...node.definitions
         ]
       };
@@ -145,12 +136,21 @@ export const getNonNullType = <T>(type: T): T => {
   return type;
 };
 
-export const getDerivedFromDirective = (field: GraphQLField<any, any>) => {
-  const directives = field.astNode?.directives ?? [];
-  return directives.find(dir => dir.name.value === 'derivedFrom');
-};
+const getDirective = (field: GraphQLField<any, any>, name: string) =>
+  (field.astNode?.directives ?? []).find(d => d.name.value === name);
 
-export const getComputedDirective = (field: GraphQLField<any, any>) => {
-  const directives = field.astNode?.directives ?? [];
-  return directives.find(dir => dir.name.value === 'computed');
-};
+export const getDerivedFromDirective = (f: GraphQLField<any, any>) =>
+  getDirective(f, 'derivedFrom');
+
+export const getComputedDirective = (f: GraphQLField<any, any>) =>
+  getDirective(f, 'computed');
+
+export const getComputedConfigs = (
+  resolvers: ComputedResolvers | undefined,
+  typeName: string
+) =>
+  resolvers
+    ? Object.entries(resolvers).find(
+        ([k]) => k.toLowerCase() === typeName.toLowerCase()
+      )?.[1] || {}
+    : {};


### PR DESCRIPTION
## Summary

Adds a `@computed` directive for schema fields resolved at query time via custom SQL subqueries instead of database columns.

- Resolvers are defined with a single `sql` function returning a Knex subquery
- `@computed` fields are skipped from DB table creation and codegen
- `@computed` fields support the full set of `orderBy` and `where` operators based on the underlying type (numeric comparisons, string contains, in/not_in, etc.)
- The SQL subquery is added to SELECT in both list (`queryMulti`) and single-entity (`DataLoader`) queries, so the value is available everywhere via standard GraphQL field resolution

## Usage

Schema:
```graphql
type Space {
  id: String!
  name: String!
  active_proposal_count: Int! @computed
}
```

Checkpoint init:
```typescript
const checkpoint = new Checkpoint(schema, {
  resolvers: {
    Space: {
      active_proposal_count: {
        sql: (knex) =>
          knex('proposals')
            .count('*')
            .where('proposals.space', knex.ref('spaces.id'))
            .where('proposals._indexer', knex.ref('spaces._indexer'))
            .where('proposals.start', '<=', knex.raw("extract(epoch from now())::integer"))
            .where('proposals.max_end', '>', knex.raw("extract(epoch from now())::integer"))
            .where('proposals.cancelled', false)
            .where('proposals.executed', false)
            .where('proposals.vetoed', false)
            .whereRaw('upper_inf(proposals.block_range)')
      }
    }
  }
});
```

Queries:
```graphql
# Sort by active proposals
{ spaces(orderBy: active_proposal_count, orderDirection: desc, first: 10) { id active_proposal_count } }

# Filter spaces with active proposals
{ spaces(where: { active_proposal_count_gt: 0 }, first: 10) { id active_proposal_count } }

# Single-entity query (DataLoader includes the subselect too)
{ space(indexer: "sep", id: "0xabc") { id active_proposal_count } }
```

## Test plan

- [x] `@computed` fields excluded from generated DB tables
- [x] `@computed` fields excluded from codegen models
- [x] `@computed` fields included in orderBy enum and where filters (full type-appropriate set)
- [x] SQL subquery added to SELECT in list queries (queryMulti)
- [x] SQL subquery added to SELECT in single-entity / nested queries (DataLoader)
- [x] ORDER BY works on computed fields (no table prefix)
- [x] WHERE filters work on computed fields via subquery
- [x] Non-computed fields continue to work as before
- [x] Tested locally with sx-monorepo active_proposal_count (list, single, ordered, filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)