### PR TITLE
fix(providers): timeout all provider fetches so hung sockets cannot freeze an indexer

### DIFF
--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -368,10 +368,11 @@ export class EvmProvider extends BaseProvider {
       topics?: (string | string[])[];
     } = {};
 
-    let signal: AbortSignal | undefined;
+    // Always set a timeout so a hung socket becomes a thrown error that the
+    // retry loops can handle, instead of silently freezing the indexer forever.
+    const signal = AbortSignal.timeout(CLIENT_TIMEOUT);
 
     if ('blockHash' in filter) {
-      signal = AbortSignal.timeout(CLIENT_TIMEOUT);
       params.blockHash = filter.blockHash;
     }
 
@@ -432,6 +433,7 @@ export class EvmProvider extends BaseProvider {
 
     let currentFrom = fromBlock;
     let currentTo = Math.min(toBlock, currentFrom + MAX_BLOCKS_PER_REQUEST);
+    let attempt = 0;
     while (true) {
       try {
         const logs = await this._getLogs({
@@ -463,9 +465,16 @@ export class EvmProvider extends BaseProvider {
           continue;
         }
 
-        this.log.error(
-          { fromBlock: currentFrom, toBlock: currentTo, address, err },
-          'getLogs failed'
+        attempt++;
+        this.log.warn(
+          {
+            attempt,
+            fromBlock: currentFrom,
+            toBlock: currentTo,
+            address,
+            err: err instanceof Error ? err.message : err
+          },
+          'getLogs failed, retrying in 5s'
         );
 
         await sleep(5000);

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -13,7 +13,14 @@ import {
 import { parseEvent } from './utils';
 import { CheckpointRecord } from '../../stores/checkpoints';
 import { ContractSourceConfig } from '../../types';
-import { sleep } from '../../utils/helpers';
+import { sleep, withTimeout } from '../../utils/helpers';
+
+/**
+ * Timeout for provider requests in milliseconds. Guards every network call so a
+ * hung socket becomes a thrown error the retry loops handle, rather than a
+ * silent indexer freeze.
+ */
+const CLIENT_TIMEOUT = 5 * 1000;
 
 class CustomJsonRpcError extends Error {
   constructor(
@@ -54,16 +61,28 @@ export class StarknetProvider extends BaseProvider {
   }
 
   async getNetworkIdentifier(): Promise<string> {
-    const result = await this.provider.getChainId();
+    const result = await withTimeout(
+      this.provider.getChainId(),
+      CLIENT_TIMEOUT,
+      'getChainId'
+    );
     return `starknet_${result}`;
   }
 
   async getLatestBlockNumber(): Promise<number> {
-    return this.provider.getBlockNumber();
+    return withTimeout(
+      this.provider.getBlockNumber(),
+      CLIENT_TIMEOUT,
+      'getBlockNumber'
+    );
   }
 
   async getBlockHash(blockNumber: number) {
-    const block = await this.provider.getBlock(blockNumber);
+    const block = await withTimeout(
+      this.provider.getBlock(blockNumber),
+      CLIENT_TIMEOUT,
+      'getBlock'
+    );
     return block.block_hash;
   }
 
@@ -76,7 +95,11 @@ export class StarknetProvider extends BaseProvider {
         skipBlockFetching && this.logsCache.has(blockNum);
 
       if (!hasPreloadedBlockEvents) {
-        block = await this.provider.getBlockWithTxHashes(blockNum);
+        block = await withTimeout(
+          this.provider.getBlockWithTxHashes(blockNum),
+          CLIENT_TIMEOUT,
+          'getBlockWithTxHashes'
+        );
       }
 
       if (block && (!isFullBlock(block) || block.block_number !== blockNum)) {
@@ -352,6 +375,7 @@ export class StarknetProvider extends BaseProvider {
   private async getBlockWithReceipts(blockId: BLOCK_ID) {
     const res = await fetch(this.instance.config.network_node_url, {
       method: 'POST',
+      signal: AbortSignal.timeout(CLIENT_TIMEOUT),
       headers: {
         'Content-Type': 'application/json'
       },
@@ -401,12 +425,16 @@ export class StarknetProvider extends BaseProvider {
 
       let continuationToken: string | undefined;
       do {
-        const result = await this.provider.getEvents({
-          from_block: { block_hash: blockHash },
-          to_block: { block_hash: blockHash },
-          chunk_size: 1000,
-          continuation_token: continuationToken
-        });
+        const result = await withTimeout(
+          this.provider.getEvents({
+            from_block: { block_hash: blockHash },
+            to_block: { block_hash: blockHash },
+            chunk_size: 1000,
+            continuation_token: continuationToken
+          }),
+          CLIENT_TIMEOUT,
+          'getEvents'
+        );
 
         events = events.concat(result.events);
 
@@ -435,24 +463,37 @@ export class StarknetProvider extends BaseProvider {
     let events: Event[] = [];
 
     let continuationToken: string | undefined;
+    let attempt = 0;
     do {
       try {
-        const result = await this.provider.getEvents({
-          from_block: { block_number: fromBlock },
-          to_block: { block_number: toBlock },
-          address: address,
-          keys: [eventNames.map(name => this.getEventHash(name))],
-          chunk_size: 1000,
-          continuation_token: continuationToken
-        });
+        const result = await withTimeout(
+          this.provider.getEvents({
+            from_block: { block_number: fromBlock },
+            to_block: { block_number: toBlock },
+            address: address,
+            keys: [eventNames.map(name => this.getEventHash(name))],
+            chunk_size: 1000,
+            continuation_token: continuationToken
+          }),
+          CLIENT_TIMEOUT,
+          'getEvents'
+        );
 
         events = events.concat(result.events);
 
         continuationToken = result.continuation_token;
       } catch (e) {
-        this.log.error(
-          { fromBlock, toBlock, continuationToken, address, err: e },
-          'getEvents failed'
+        attempt++;
+        this.log.warn(
+          {
+            attempt,
+            fromBlock,
+            toBlock,
+            continuationToken,
+            address,
+            err: e instanceof Error ? e.message : e
+          },
+          'getEvents failed, retrying in 5s'
         );
 
         await sleep(5000);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,30 @@ export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * Rejects with a timeout error if the provided promise does not settle within
+ * `ms` milliseconds. Used to guard provider network calls that cannot be passed
+ * an AbortSignal, so a hung socket becomes a thrown error the retry loops can
+ * handle instead of silently freezing an indexer forever.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label = 'request'
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
+  });
+
+  return Promise.race([promise, timeout]).finally(() =>
+    clearTimeout(timer)
+  ) as Promise<T>;
+}
+
 export function chunk<T>(array: T[], chunkSize: number) {
   const chunks = [] as T[][];
   let index = 0;

--- a/test/unit/utils/helpers.test.ts
+++ b/test/unit/utils/helpers.test.ts
@@ -1,4 +1,18 @@
-import { chunk } from '../../../src/utils/helpers';
+import { chunk, withTimeout } from '../../../src/utils/helpers';
+
+describe('withTimeout', () => {
+  it('resolves when the promise settles before the timeout', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 50)).resolves.toBe('ok');
+  });
+
+  it('rejects when the promise never settles within the timeout', async () => {
+    const neverResolves = new Promise(() => {});
+
+    await expect(withTimeout(neverResolves, 20, 'getLogs')).rejects.toThrow(
+      'getLogs timed out after 20ms'
+    );
+  });
+});
 
 describe('chunk', () => {
   it('should chunk array', () => {


### PR DESCRIPTION
## Symptoms

sx-api indexers silently freeze. On 2026-06-11 we saw the "double box" freeze with chains dying silently around 06:21 and 06:47 UTC: an indexer stops advancing, emits no error, and never recovers until restarted.

## Mechanism

A provider network fetch hangs on a dead/half-open socket. Because there is no timeout, the awaited promise never settles, so the indexer's processing loop is parked forever. The outer `getLogs`/`getEvents` retry loops only re-loop on a thrown error, so a hang (no throw) is invisible and unrecoverable, with nothing in the logs.

Specifically (diagnosed against the installed `@snapshot-labs/checkpoint@0.1.0-beta.70`):
- EVM `_getLogs`: the abort `signal` was set ONLY on the `blockHash` path. The `fromBlock`/`toBlock` range path passed `signal = undefined` to `fetch`, so the range request could hang forever.
- Starknet `getBlockWithReceipts`: a bare `fetch` with no `signal` at all. The `RpcProvider` calls (`getChainId`, `getBlockNumber`, `getBlock`, `getBlockWithTxHashes`, `getEvents`) also have no timeout (starknet 5.x exposes no per-request AbortSignal).
- The retry loops `while (true) { try { ... } catch { sleep(5000) } }` log nothing useful and never trip when the call hangs instead of throwing.

## What changed

- EVM `_getLogs`: always set `AbortSignal.timeout(CLIENT_TIMEOUT)` for every request (both the blockHash and the range path), so every fetch can time out.
- Starknet: add a shared `withTimeout(promise, ms, label)` helper in `utils/helpers.ts` and wrap every `RpcProvider` network call with it; add `AbortSignal.timeout(CLIENT_TIMEOUT)` to the raw `getBlockWithReceipts` fetch. Any hang now becomes a thrown error the existing retry loop already handles.
- Make both retry loops observable: log a `warn` per attempt with the error message and an attempt counter, so a flapping RPC shows up in logs instead of silently.
- Add unit tests for `withTimeout` (resolves before timeout, rejects when the promise never settles).

`CLIENT_TIMEOUT` stays at 5s, matching the existing EVM client timeout.

## Verification

- `yarn build` (tsc): clean
- `yarn lint`: clean
- `yarn test`: 70 passed (incl. 2 new `withTimeout` tests)

## Links

- sx-monorepo #2162
- Diagnosis: sx-monorepo #2162 comment 4681579797

Plain text, no merge requested - leaving for review.