### PR TITLE
fix(evm): deduplicate topics

### DIFF
--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -545,9 +545,13 @@ export class EvmProvider extends BaseProvider {
     let events: Log[] = [];
     for (const chunk of chunks) {
       const address = chunk.map(source => source.contract);
-      const topics = chunk.flatMap(source =>
-        source.events.map(event => this.getEventHash(event.name))
-      );
+      const topics = [
+        ...new Set(
+          chunk.flatMap(source =>
+            source.events.map(event => this.getEventHash(event.name))
+          )
+        )
+      ];
 
       const chunkEvents = await this.getLogs(fromBlock, toBlock, address, [
         topics


### PR DESCRIPTION
This list was being set for each source without deduplication so it could grow by a lot if there is lots of sources.

Generally it shouldn't matter, but:
1. If it grows to huge sizes it will impact requests/server involved.
2. Some providers have limit on the numbers of topics and they might look at the list as-is.