### PR TITLE
chore(evm): handle Edge RPC range errors

### DIFF
--- a/src/providers/evm/helpers.test.ts
+++ b/src/providers/evm/helpers.test.ts
@@ -101,4 +101,42 @@ describe('getRangeHint', () => {
       });
     });
   });
+
+  describe('Edge RPC error (code: -32012)', () => {
+    it('should return half the current range', () => {
+      const edgeError = new CustomJsonRpcError(
+        'getLogs request exceeded max allowed range',
+        -32012,
+        {}
+      );
+
+      const result = getRangeHint(edgeError, {
+        from: 1000,
+        to: 2000
+      });
+
+      expect(result).toEqual({
+        from: 1000,
+        to: 1500
+      });
+    });
+
+    it('should round up', () => {
+      const edgeError = new CustomJsonRpcError(
+        'getLogs request exceeded max allowed range',
+        -32012,
+        {}
+      );
+
+      const result = getRangeHint(edgeError, {
+        from: 1000,
+        to: 1501
+      });
+
+      expect(result).toEqual({
+        from: 1000,
+        to: 1251
+      });
+    });
+  });
 });

--- a/src/providers/evm/helpers.ts
+++ b/src/providers/evm/helpers.ts
@@ -26,7 +26,8 @@ export function getRangeHint(err: unknown, currentRange: Range): Range | null {
   }
 
   // Ankr (code: -32062): Block range is too large
-  if (err.code === -32062) {
+  // Edge RPC (code: -32012): getLogs request exceeded max allowed range
+  if (err.code === -32062 || err.code === -32012) {
     // We have no range in the error data, so we return the current range, but half as long
     return {
       from: currentRange.from,


### PR DESCRIPTION
We are seeing Base indexer getting stuck due to Edge RPC range errors.