### PR TITLE
feat: add syncVersion helper

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -8,7 +8,12 @@ import { createPgPool } from './pg';
 import { BaseIndexer } from './providers';
 import { register } from './register';
 import { checkpointConfigSchema } from './schemas';
-import { CheckpointsStore } from './stores/checkpoints';
+import {
+  CheckpointsStore,
+  GLOBAL_INDEXER,
+  METADATA_VALUE_MAX_LENGTH,
+  MetadataId
+} from './stores/checkpoints';
 import { CheckpointConfig, CheckpointOptions } from './types';
 import { extendSchema } from './utils/graphql';
 import { createLogger, Logger, LogLevel } from './utils/logger';
@@ -171,6 +176,75 @@ export default class Checkpoint {
     for (const container of this.containers.values()) {
       await container.resetMetadata();
     }
+  }
+
+  /**
+   * Resets Checkpoint (metadata and all indexed entities) only when the
+   * provided application version tag differs from the one stored on a previous
+   * run.
+   *
+   * Use this to automatically reset the database when your application changes
+   * in ways Checkpoint can't detect on its own through `resetOnConfigChange`,
+   * such as changes to writer logic, feature flags, or which indexers are
+   * registered. The version tag is an opaque string you control, typically
+   * derived from a git commit hash combined with any flags that affect
+   * indexing. It is stored as-is and must be at most
+   * `METADATA_VALUE_MAX_LENGTH` characters long.
+   *
+   * If no version tag is provided, this always resets. This is a safe default
+   * for environments without version tracking.
+   *
+   * This should be called before `start()`.
+   *
+   * Returns true if a reset was performed, false otherwise.
+   *
+   */
+  public async syncVersion(versionTag?: string): Promise<boolean> {
+    await this.store.createStore();
+
+    if (!versionTag) {
+      this.log.info('no version tag provided, resetting');
+
+      await this.resetMetadata();
+      await this.reset();
+
+      return true;
+    }
+
+    if (versionTag.length > METADATA_VALUE_MAX_LENGTH) {
+      throw new Error(
+        `versionTag must be at most ${METADATA_VALUE_MAX_LENGTH} characters long`
+      );
+    }
+
+    const storedVersionTag = await this.store.getMetadata(
+      GLOBAL_INDEXER,
+      MetadataId.VersionTag
+    );
+
+    if (storedVersionTag === versionTag) {
+      this.log.info({ versionTag }, 'version tag unchanged, continuing');
+
+      return false;
+    }
+
+    this.log.info(
+      { versionTag, storedVersionTag },
+      storedVersionTag
+        ? 'version tag changed, resetting'
+        : 'no stored version tag, resetting'
+    );
+
+    await this.resetMetadata();
+    await this.reset();
+
+    await this.store.setMetadata(
+      GLOBAL_INDEXER,
+      MetadataId.VersionTag,
+      versionTag
+    );
+
+    return true;
   }
 
   /**

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -54,10 +54,19 @@ export enum MetadataId {
   NetworkIdentifier = 'network_identifier',
   StartBlock = 'start_block',
   ConfigChecksum = 'config_checksum',
-  SchemaVersion = 'schema_version'
+  SchemaVersion = 'schema_version',
+  VersionTag = 'version_tag'
 }
 
+/**
+ * Indexer name used to store metadata that is not tied to a single indexer,
+ * such as the application version tag.
+ */
+export const GLOBAL_INDEXER = '_global';
+
 export const INTERNAL_TABLES = Object.values(Table);
+
+export const METADATA_VALUE_MAX_LENGTH = 128;
 
 const CheckpointIdSize = 10;
 
@@ -133,7 +142,10 @@ export class CheckpointsStore {
       builder = builder.createTable(Table.Metadata, t => {
         t.string(Fields.Metadata.Id, 20);
         t.string(Fields.Metadata.Indexer).notNullable();
-        t.string(Fields.Metadata.Value, 128).notNullable();
+        t.string(
+          Fields.Metadata.Value,
+          METADATA_VALUE_MAX_LENGTH
+        ).notNullable();
         t.primary([Fields.Metadata.Id, Fields.Metadata.Indexer]);
       });
     }


### PR DESCRIPTION
Currently our APIs handle versionTag based reset manually. This is repetetive so it can be included in Checkpoint itself. This is flexible as consumers build the versionTag themselves.

```ts
import Checkpoint from '@snapshot-labs/checkpoint';

const GIT_COMMIT = process.env.GIT_COMMIT;
const ENABLE_SNAPSHOT_X = process.env.ENABLE_SNAPSHOT_X === 'true';
const ENABLE_GOVERNOR_BRAVO = process.env.ENABLE_GOVERNOR_BRAVO === 'true';

async function startIndexer(checkpoint: Checkpoint) {
  addStarknetIndexers(checkpoint);
  addEvmIndexers(checkpoint);

  // undefined when GIT_COMMIT is missing → always resets (safe default)
  const versionTag = GIT_COMMIT
    ? `commit:${GIT_COMMIT}|snapshotX:${ENABLE_SNAPSHOT_X}|governorBravo:${ENABLE_GOVERNOR_BRAVO}`
    : undefined;

  await checkpoint.syncVersion(versionTag);

  checkpoint.start();
}
```