### PR TITLE
fix: expose enum fields as String in where inputs

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -483,15 +483,20 @@ export class GqlEntityController {
         }
 
         if ((nonNullFieldType as GraphQLScalarType).name !== 'Text') {
-          whereInputConfig.fields[`${field.name}`] = { type: nonNullFieldType };
+          const filterType =
+            nonNullFieldType instanceof GraphQLEnumType
+              ? GraphQLString
+              : nonNullFieldType;
+
+          whereInputConfig.fields[`${field.name}`] = { type: filterType };
           whereInputConfig.fields[`${field.name}_not`] = {
-            type: nonNullFieldType
+            type: filterType
           };
           whereInputConfig.fields[`${field.name}_in`] = {
-            type: new GraphQLList(nonNullFieldType)
+            type: new GraphQLList(filterType)
           };
           whereInputConfig.fields[`${field.name}_not_in`] = {
-            type: new GraphQLList(nonNullFieldType)
+            type: new GraphQLList(filterType)
           };
         }
 

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -17,6 +17,49 @@ create index \`votes_decimal_index\` on \`votes\` (\`decimal\`);
 create index \`votes_big_decimal_index\` on \`votes\` (\`big_decimal\`)"
 `;
 
+exports[`GqlEntityController generateQueryFields should expose enum fields as String in where inputs 1`] = `
+"type Query {
+  proposal(id: Int!, indexer: String, block: Int): Proposal
+  proposals(first: Int, skip: Int, orderBy: Proposal_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Proposal_filter): [Proposal!]!
+}
+
+type Proposal {
+  id: Int!
+  state: ProposalState!
+}
+
+enum ProposalState {
+  pending
+  active
+  closed
+}
+
+enum Proposal_orderBy {
+  id
+  state
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+input Proposal_filter {
+  id_gt: Int
+  id_gte: Int
+  id_lt: Int
+  id_lte: Int
+  id: Int
+  id_not: Int
+  id_in: [Int]
+  id_not_in: [Int]
+  state: String
+  state_not: String
+  state_in: [String]
+  state_not_in: [String]
+}"
+`;
+
 exports[`GqlEntityController generateQueryFields should work 1`] = `
 "type Query {
   vote(id: Int!, indexer: String, block: Int): Vote

--- a/test/unit/graphql/controller.test.ts
+++ b/test/unit/graphql/controller.test.ts
@@ -22,6 +22,29 @@ type Vote {
       expect(schema).toMatchSnapshot();
     });
 
+    it('should expose enum fields as String in where inputs', () => {
+      const controller = new GqlEntityController(`
+type Proposal {
+  id: Int!
+  state: ProposalState!
+}
+
+enum ProposalState {
+  pending
+  active
+  closed
+}
+  `);
+      const queryFields = controller.generateQueryFields();
+      const querySchema = new GraphQLObjectType({
+        name: 'Query',
+        fields: queryFields
+      });
+
+      const schema = printSchema(new GraphQLSchema({ query: querySchema }));
+      expect(schema).toMatchSnapshot();
+    });
+
     // list of error table tests
     describe.each([
       {


### PR DESCRIPTION
## Summary

When an entity field is typed as a GraphQL enum, the generated `where` input fields (`field`, `field_not`, `field_in`, `field_not_in`) are now typed as `String` instead of the enum. The output field keeps its enum type (validation and introspection intact).

## Why

Consumers that codegen their types from the query schema (e.g. the sx-monorepo UI) construct filter objects in existing code. If tightening an entity field from `String` to an enum also tightens the filter input, every downstream client is forced to adapt its filter code in lockstep with the schema change. Typing filters as `String` keeps filter shapes stable (and matches hub API filter semantics) while the response side still gets the fully typed enum.

Concrete motivation: adding `state: ProposalState! @computed` to the sx-monorepo API (snapshot-labs/sx-monorepo#2226) without breaking the UI's regenerated `Proposal_filter` types.

## Test plan

- New unit test snapshot: entity with an enum field generates `state: ProposalState!` on the type and `state: String` / `state_not` / `state_in` / `state_not_in` in the filter input
- Full jest suite passes (23 snapshots)
- Verified end-to-end in sx-monorepo: enum output field, string-valued filters, orderBy on the computed enum field, against a live Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)