### PR TITLE
fix: apply keepalive and timeouts to all database connections

### DIFF
--- a/src/knex.ts
+++ b/src/knex.ts
@@ -70,7 +70,11 @@ export function getConnectionData(connectionString: string) {
       password: connectionConfig.password,
       host: connectionConfig.hosts[0].name,
       port: connectionConfig.hosts[0].port,
-      ssl: Object.keys(sslConfig).length > 0 ? sslConfig : undefined
+      ssl: Object.keys(sslConfig).length > 0 ? sslConfig : undefined,
+      keepAlive: true,
+      keepAliveInitialDelayMillis: 10_000,
+      connectionTimeoutMillis: 30_000,
+      query_timeout: 60_000
     }
   };
 }

--- a/src/pg.ts
+++ b/src/pg.ts
@@ -9,10 +9,5 @@ import { getConnectionData } from './knex';
 export const createPgPool = (connectionString: string): Pool => {
   const { connection } = getConnectionData(connectionString);
 
-  const config = {
-    ...connection,
-    connectionTimeoutMillis: 30000 // 30 seconds
-  };
-
-  return new Pool(config);
+  return new Pool(connection);
 };

--- a/test/unit/knex.test.ts
+++ b/test/unit/knex.test.ts
@@ -15,7 +15,11 @@ describe('createKnexConfig', () => {
         password: 'default_password',
         port: 3306,
         ssl: undefined,
-        user: 'root'
+        user: 'root',
+        keepAlive: true,
+        keepAliveInitialDelayMillis: 10_000,
+        connectionTimeoutMillis: 30_000,
+        query_timeout: 60_000
       }
     });
   });


### PR DESCRIPTION
We have seen cases of hung TCP connections freezing indexer forever. To address that we should have a fail-safe on client side to kill such connections and retry.