### PR TITLE
fix: avoid unrecoverable database write failures

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -107,6 +107,28 @@ export const getJSType = (
   return { isNullable, isList, baseType };
 };
 
+/** Maximum length of varchar columns created for String/ID fields. */
+const VARCHAR_LENGTH = 256;
+
+const isVarcharField = (type: GraphQLType): boolean => {
+  const nonNullType = type instanceof GraphQLNonNull ? type.ofType : type;
+
+  if (nonNullType === GraphQLString || nonNullType === GraphQLID) return true;
+
+  if (nonNullType instanceof GraphQLObjectType) {
+    const idField = nonNullType.getFields()['id'];
+
+    return (
+      idField !== undefined &&
+      idField.type instanceof GraphQLNonNull &&
+      idField.type.ofType instanceof GraphQLScalarType &&
+      ['String', 'ID'].includes(idField.type.ofType.name)
+    );
+  }
+
+  return false;
+};
+
 const isPersistedField = (field: GraphQLField<any, any>) => {
   if (getComputedDirective(field)) return false;
 
@@ -159,6 +181,16 @@ export const codegen = (
         ? `  constructor(id, indexerName) {\n`
         : `  constructor(id: ${idType.baseType}, indexerName: string) {\n`;
     contents += `    super(${modelName}.tableName, indexerName);\n\n`;
+    if (idField && isVarcharField(idField.type)) {
+      contents += `    if ([...id].length > ${VARCHAR_LENGTH}) {\n`;
+      contents += `      throw new Error('Value for ${modelName}.id exceeds ${VARCHAR_LENGTH} characters');\n`;
+      contents += `    }\n\n`;
+    }
+    if (idType.baseType === 'string') {
+      contents += `    if (id.includes('\\u0000')) {\n`;
+      contents += `      throw new Error('Value for ${modelName}.id contains a NUL character');\n`;
+      contents += `    }\n\n`;
+    }
     persistedFields.forEach(field => {
       const rawInitialValue = getInitialValue(field.type, decimalTypes);
       const initialValue =
@@ -223,6 +255,24 @@ export const codegen = (
         format === 'javascript'
           ? `  set ${field.name}(value) {\n`
           : `  set ${field.name}(value: ${setterAnnotation}) {\n`;
+      if (isVarcharField(field.type)) {
+        const lengthCheck = `[...value].length > ${VARCHAR_LENGTH}`;
+        contents += isNullable
+          ? `    if (value !== null && ${lengthCheck}) {\n`
+          : `    if (${lengthCheck}) {\n`;
+        contents += `      throw new Error('Value for ${modelName}.${field.name} exceeds ${VARCHAR_LENGTH} characters');\n`;
+        contents += `    }\n\n`;
+      }
+      if (baseType === 'string' || baseType === 'string[]') {
+        const nulCheck = isList
+          ? `value.some(item => typeof item === 'string' && item.includes('\\u0000'))`
+          : `value.includes('\\u0000')`;
+        contents += isNullable
+          ? `    if (value !== null && ${nulCheck}) {\n`
+          : `    if (${nulCheck}) {\n`;
+        contents += `      throw new Error('Value for ${modelName}.${field.name} contains a NUL character');\n`;
+        contents += `    }\n\n`;
+      }
       contents += `    this.set('${field.name}', ${setterExpression});\n`;
       contents += `  }\n\n`;
     });

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -182,12 +182,12 @@ export const codegen = (
         : `  constructor(id: ${idType.baseType}, indexerName: string) {\n`;
     contents += `    super(${modelName}.tableName, indexerName);\n\n`;
     if (idField && isVarcharField(idField.type)) {
-      contents += `    if ([...id].length > ${VARCHAR_LENGTH}) {\n`;
+      contents += `    if (typeof id === 'string' && [...id].length > ${VARCHAR_LENGTH}) {\n`;
       contents += `      throw new Error('Value for ${modelName}.id exceeds ${VARCHAR_LENGTH} characters');\n`;
       contents += `    }\n\n`;
     }
     if (idType.baseType === 'string') {
-      contents += `    if (id.includes('\\u0000')) {\n`;
+      contents += `    if (typeof id === 'string' && id.includes('\\u0000')) {\n`;
       contents += `      throw new Error('Value for ${modelName}.id contains a NUL character');\n`;
       contents += `    }\n\n`;
     }
@@ -256,20 +256,15 @@ export const codegen = (
           ? `  set ${field.name}(value) {\n`
           : `  set ${field.name}(value: ${setterAnnotation}) {\n`;
       if (isVarcharField(field.type)) {
-        const lengthCheck = `[...value].length > ${VARCHAR_LENGTH}`;
-        contents += isNullable
-          ? `    if (value !== null && ${lengthCheck}) {\n`
-          : `    if (${lengthCheck}) {\n`;
+        contents += `    if (typeof value === 'string' && [...value].length > ${VARCHAR_LENGTH}) {\n`;
         contents += `      throw new Error('Value for ${modelName}.${field.name} exceeds ${VARCHAR_LENGTH} characters');\n`;
         contents += `    }\n\n`;
       }
       if (baseType === 'string' || baseType === 'string[]') {
         const nulCheck = isList
-          ? `value.some(item => typeof item === 'string' && item.includes('\\u0000'))`
-          : `value.includes('\\u0000')`;
-        contents += isNullable
-          ? `    if (value !== null && ${nulCheck}) {\n`
-          : `    if (${nulCheck}) {\n`;
+          ? `Array.isArray(value) && value.some(item => typeof item === 'string' && item.includes('\\u0000'))`
+          : `typeof value === 'string' && value.includes('\\u0000')`;
+        contents += `    if (${nulCheck}) {\n`;
         contents += `      throw new Error('Value for ${modelName}.${field.name} contains a NUL character');\n`;
         contents += `    }\n\n`;
       }

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -265,7 +265,7 @@ export class GqlEntityController {
               column = column.notNullable();
             }
 
-            if (!['text', 'json'].includes(sqlType.name)) {
+            if (!['text', 'json', 'jsonb'].includes(sqlType.name)) {
               column.index();
             }
           });

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -11,6 +11,14 @@ export class Space extends Model {
   constructor(id: string, indexerName: string) {
     super(Space.tableName, indexerName);
 
+    if ([...id].length > 256) {
+      throw new Error('Value for Space.id exceeds 256 characters');
+    }
+
+    if (id.includes('\\u0000')) {
+      throw new Error('Value for Space.id contains a NUL character');
+    }
+
     this.initialSet('id', id);
     this.initialSet('name', null);
     this.initialSet('about', null);
@@ -45,6 +53,14 @@ export class Space extends Model {
   }
 
   set id(value: string) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Space.id exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Space.id contains a NUL character');
+    }
+
     this.set('id', value);
   }
 
@@ -53,6 +69,14 @@ export class Space extends Model {
   }
 
   set name(value: string | null) {
+    if (value !== null && [...value].length > 256) {
+      throw new Error('Value for Space.name exceeds 256 characters');
+    }
+
+    if (value !== null && value.includes('\\u0000')) {
+      throw new Error('Value for Space.name contains a NUL character');
+    }
+
     this.set('name', value);
   }
 
@@ -61,6 +85,14 @@ export class Space extends Model {
   }
 
   set about(value: string | null) {
+    if (value !== null && [...value].length > 256) {
+      throw new Error('Value for Space.about exceeds 256 characters');
+    }
+
+    if (value !== null && value.includes('\\u0000')) {
+      throw new Error('Value for Space.about contains a NUL character');
+    }
+
     this.set('about', value);
   }
 
@@ -69,6 +101,14 @@ export class Space extends Model {
   }
 
   set controller(value: string) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Space.controller exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Space.controller contains a NUL character');
+    }
+
     this.set('controller', value);
   }
 
@@ -101,6 +141,10 @@ export class Space extends Model {
   }
 
   set strategies(value: string[]) {
+    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+      throw new Error('Value for Space.strategies contains a NUL character');
+    }
+
     this.set('strategies', JSON.stringify(value));
   }
 
@@ -109,6 +153,10 @@ export class Space extends Model {
   }
 
   set strategies_nonnull(value: string[]) {
+    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+      throw new Error('Value for Space.strategies_nonnull contains a NUL character');
+    }
+
     this.set('strategies_nonnull', JSON.stringify(value));
   }
 
@@ -117,6 +165,14 @@ export class Space extends Model {
   }
 
   set _indexer(value: string) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Space._indexer exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Space._indexer contains a NUL character');
+    }
+
     this.set('_indexer', value);
   }
 }
@@ -128,6 +184,14 @@ export class Proposal extends Model {
 
   constructor(id: string, indexerName: string) {
     super(Proposal.tableName, indexerName);
+
+    if ([...id].length > 256) {
+      throw new Error('Value for Proposal.id exceeds 256 characters');
+    }
+
+    if (id.includes('\\u0000')) {
+      throw new Error('Value for Proposal.id contains a NUL character');
+    }
 
     this.initialSet('id', id);
     this.initialSet('proposal_id', 0);
@@ -161,6 +225,14 @@ export class Proposal extends Model {
   }
 
   set id(value: string) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Proposal.id exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.id contains a NUL character');
+    }
+
     this.set('id', value);
   }
 
@@ -177,6 +249,14 @@ export class Proposal extends Model {
   }
 
   set space(value: string) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Proposal.space exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.space contains a NUL character');
+    }
+
     this.set('space', value);
   }
 
@@ -185,6 +265,10 @@ export class Proposal extends Model {
   }
 
   set title(value: string) {
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.title contains a NUL character');
+    }
+
     this.set('title', value);
   }
 
@@ -209,6 +293,10 @@ export class Proposal extends Model {
   }
 
   set progress(value: string) {
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.progress contains a NUL character');
+    }
+
     this.set('progress', value);
   }
 
@@ -217,6 +305,14 @@ export class Proposal extends Model {
   }
 
   set _indexer(value: string) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Proposal._indexer exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal._indexer contains a NUL character');
+    }
+
     this.set('_indexer', value);
   }
 }
@@ -233,6 +329,14 @@ export class Space extends Model {
 
   constructor(id, indexerName) {
     super(Space.tableName, indexerName);
+
+    if ([...id].length > 256) {
+      throw new Error('Value for Space.id exceeds 256 characters');
+    }
+
+    if (id.includes('\\u0000')) {
+      throw new Error('Value for Space.id contains a NUL character');
+    }
 
     this.initialSet('id', id);
     this.initialSet('name', null);
@@ -268,6 +372,14 @@ export class Space extends Model {
   }
 
   set id(value) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Space.id exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Space.id contains a NUL character');
+    }
+
     this.set('id', value);
   }
 
@@ -276,6 +388,14 @@ export class Space extends Model {
   }
 
   set name(value) {
+    if (value !== null && [...value].length > 256) {
+      throw new Error('Value for Space.name exceeds 256 characters');
+    }
+
+    if (value !== null && value.includes('\\u0000')) {
+      throw new Error('Value for Space.name contains a NUL character');
+    }
+
     this.set('name', value);
   }
 
@@ -284,6 +404,14 @@ export class Space extends Model {
   }
 
   set about(value) {
+    if (value !== null && [...value].length > 256) {
+      throw new Error('Value for Space.about exceeds 256 characters');
+    }
+
+    if (value !== null && value.includes('\\u0000')) {
+      throw new Error('Value for Space.about contains a NUL character');
+    }
+
     this.set('about', value);
   }
 
@@ -292,6 +420,14 @@ export class Space extends Model {
   }
 
   set controller(value) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Space.controller exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Space.controller contains a NUL character');
+    }
+
     this.set('controller', value);
   }
 
@@ -324,6 +460,10 @@ export class Space extends Model {
   }
 
   set strategies(value) {
+    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+      throw new Error('Value for Space.strategies contains a NUL character');
+    }
+
     this.set('strategies', JSON.stringify(value));
   }
 
@@ -332,6 +472,10 @@ export class Space extends Model {
   }
 
   set strategies_nonnull(value) {
+    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+      throw new Error('Value for Space.strategies_nonnull contains a NUL character');
+    }
+
     this.set('strategies_nonnull', JSON.stringify(value));
   }
 
@@ -340,6 +484,14 @@ export class Space extends Model {
   }
 
   set _indexer(value) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Space._indexer exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Space._indexer contains a NUL character');
+    }
+
     this.set('_indexer', value);
   }
 }
@@ -351,6 +503,14 @@ export class Proposal extends Model {
 
   constructor(id, indexerName) {
     super(Proposal.tableName, indexerName);
+
+    if ([...id].length > 256) {
+      throw new Error('Value for Proposal.id exceeds 256 characters');
+    }
+
+    if (id.includes('\\u0000')) {
+      throw new Error('Value for Proposal.id contains a NUL character');
+    }
 
     this.initialSet('id', id);
     this.initialSet('proposal_id', 0);
@@ -384,6 +544,14 @@ export class Proposal extends Model {
   }
 
   set id(value) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Proposal.id exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.id contains a NUL character');
+    }
+
     this.set('id', value);
   }
 
@@ -400,6 +568,14 @@ export class Proposal extends Model {
   }
 
   set space(value) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Proposal.space exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.space contains a NUL character');
+    }
+
     this.set('space', value);
   }
 
@@ -408,6 +584,10 @@ export class Proposal extends Model {
   }
 
   set title(value) {
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.title contains a NUL character');
+    }
+
     this.set('title', value);
   }
 
@@ -432,6 +612,10 @@ export class Proposal extends Model {
   }
 
   set progress(value) {
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal.progress contains a NUL character');
+    }
+
     this.set('progress', value);
   }
 
@@ -440,6 +624,14 @@ export class Proposal extends Model {
   }
 
   set _indexer(value) {
+    if ([...value].length > 256) {
+      throw new Error('Value for Proposal._indexer exceeds 256 characters');
+    }
+
+    if (value.includes('\\u0000')) {
+      throw new Error('Value for Proposal._indexer contains a NUL character');
+    }
+
     this.set('_indexer', value);
   }
 }

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -11,11 +11,11 @@ export class Space extends Model {
   constructor(id: string, indexerName: string) {
     super(Space.tableName, indexerName);
 
-    if ([...id].length > 256) {
+    if (typeof id === 'string' && [...id].length > 256) {
       throw new Error('Value for Space.id exceeds 256 characters');
     }
 
-    if (id.includes('\\u0000')) {
+    if (typeof id === 'string' && id.includes('\\u0000')) {
       throw new Error('Value for Space.id contains a NUL character');
     }
 
@@ -53,11 +53,11 @@ export class Space extends Model {
   }
 
   set id(value: string) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.id exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.id contains a NUL character');
     }
 
@@ -69,11 +69,11 @@ export class Space extends Model {
   }
 
   set name(value: string | null) {
-    if (value !== null && [...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.name exceeds 256 characters');
     }
 
-    if (value !== null && value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.name contains a NUL character');
     }
 
@@ -85,11 +85,11 @@ export class Space extends Model {
   }
 
   set about(value: string | null) {
-    if (value !== null && [...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.about exceeds 256 characters');
     }
 
-    if (value !== null && value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.about contains a NUL character');
     }
 
@@ -101,11 +101,11 @@ export class Space extends Model {
   }
 
   set controller(value: string) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.controller exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.controller contains a NUL character');
     }
 
@@ -141,7 +141,7 @@ export class Space extends Model {
   }
 
   set strategies(value: string[]) {
-    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+    if (Array.isArray(value) && value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
       throw new Error('Value for Space.strategies contains a NUL character');
     }
 
@@ -153,7 +153,7 @@ export class Space extends Model {
   }
 
   set strategies_nonnull(value: string[]) {
-    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+    if (Array.isArray(value) && value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
       throw new Error('Value for Space.strategies_nonnull contains a NUL character');
     }
 
@@ -165,11 +165,11 @@ export class Space extends Model {
   }
 
   set _indexer(value: string) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space._indexer exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space._indexer contains a NUL character');
     }
 
@@ -185,11 +185,11 @@ export class Proposal extends Model {
   constructor(id: string, indexerName: string) {
     super(Proposal.tableName, indexerName);
 
-    if ([...id].length > 256) {
+    if (typeof id === 'string' && [...id].length > 256) {
       throw new Error('Value for Proposal.id exceeds 256 characters');
     }
 
-    if (id.includes('\\u0000')) {
+    if (typeof id === 'string' && id.includes('\\u0000')) {
       throw new Error('Value for Proposal.id contains a NUL character');
     }
 
@@ -225,11 +225,11 @@ export class Proposal extends Model {
   }
 
   set id(value: string) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Proposal.id exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.id contains a NUL character');
     }
 
@@ -249,11 +249,11 @@ export class Proposal extends Model {
   }
 
   set space(value: string) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Proposal.space exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.space contains a NUL character');
     }
 
@@ -265,7 +265,7 @@ export class Proposal extends Model {
   }
 
   set title(value: string) {
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.title contains a NUL character');
     }
 
@@ -293,7 +293,7 @@ export class Proposal extends Model {
   }
 
   set progress(value: string) {
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.progress contains a NUL character');
     }
 
@@ -305,11 +305,11 @@ export class Proposal extends Model {
   }
 
   set _indexer(value: string) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Proposal._indexer exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal._indexer contains a NUL character');
     }
 
@@ -330,11 +330,11 @@ export class Space extends Model {
   constructor(id, indexerName) {
     super(Space.tableName, indexerName);
 
-    if ([...id].length > 256) {
+    if (typeof id === 'string' && [...id].length > 256) {
       throw new Error('Value for Space.id exceeds 256 characters');
     }
 
-    if (id.includes('\\u0000')) {
+    if (typeof id === 'string' && id.includes('\\u0000')) {
       throw new Error('Value for Space.id contains a NUL character');
     }
 
@@ -372,11 +372,11 @@ export class Space extends Model {
   }
 
   set id(value) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.id exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.id contains a NUL character');
     }
 
@@ -388,11 +388,11 @@ export class Space extends Model {
   }
 
   set name(value) {
-    if (value !== null && [...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.name exceeds 256 characters');
     }
 
-    if (value !== null && value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.name contains a NUL character');
     }
 
@@ -404,11 +404,11 @@ export class Space extends Model {
   }
 
   set about(value) {
-    if (value !== null && [...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.about exceeds 256 characters');
     }
 
-    if (value !== null && value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.about contains a NUL character');
     }
 
@@ -420,11 +420,11 @@ export class Space extends Model {
   }
 
   set controller(value) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space.controller exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space.controller contains a NUL character');
     }
 
@@ -460,7 +460,7 @@ export class Space extends Model {
   }
 
   set strategies(value) {
-    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+    if (Array.isArray(value) && value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
       throw new Error('Value for Space.strategies contains a NUL character');
     }
 
@@ -472,7 +472,7 @@ export class Space extends Model {
   }
 
   set strategies_nonnull(value) {
-    if (value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
+    if (Array.isArray(value) && value.some(item => typeof item === 'string' && item.includes('\\u0000'))) {
       throw new Error('Value for Space.strategies_nonnull contains a NUL character');
     }
 
@@ -484,11 +484,11 @@ export class Space extends Model {
   }
 
   set _indexer(value) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Space._indexer exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Space._indexer contains a NUL character');
     }
 
@@ -504,11 +504,11 @@ export class Proposal extends Model {
   constructor(id, indexerName) {
     super(Proposal.tableName, indexerName);
 
-    if ([...id].length > 256) {
+    if (typeof id === 'string' && [...id].length > 256) {
       throw new Error('Value for Proposal.id exceeds 256 characters');
     }
 
-    if (id.includes('\\u0000')) {
+    if (typeof id === 'string' && id.includes('\\u0000')) {
       throw new Error('Value for Proposal.id contains a NUL character');
     }
 
@@ -544,11 +544,11 @@ export class Proposal extends Model {
   }
 
   set id(value) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Proposal.id exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.id contains a NUL character');
     }
 
@@ -568,11 +568,11 @@ export class Proposal extends Model {
   }
 
   set space(value) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Proposal.space exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.space contains a NUL character');
     }
 
@@ -584,7 +584,7 @@ export class Proposal extends Model {
   }
 
   set title(value) {
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.title contains a NUL character');
     }
 
@@ -612,7 +612,7 @@ export class Proposal extends Model {
   }
 
   set progress(value) {
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal.progress contains a NUL character');
     }
 
@@ -624,11 +624,11 @@ export class Proposal extends Model {
   }
 
   set _indexer(value) {
-    if ([...value].length > 256) {
+    if (typeof value === 'string' && [...value].length > 256) {
       throw new Error('Value for Proposal._indexer exceeds 256 characters');
     }
 
-    if (value.includes('\\u0000')) {
+    if (typeof value === 'string' && value.includes('\\u0000')) {
       throw new Error('Value for Proposal._indexer contains a NUL character');
     }
 

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -8,6 +8,7 @@ import {
   getTypeInfo
 } from '../../src/codegen';
 import { GqlEntityController } from '../../src/graphql/controller';
+import Model from '../../src/orm/model';
 import { extendSchema } from '../../src/utils/graphql';
 
 const SCHEMA_SOURCE = `
@@ -200,5 +201,122 @@ describe('codegen', () => {
     expect(
       codegen(controller, overridesConfig, 'javascript')
     ).toMatchSnapshot();
+  });
+});
+
+describe('generated models', () => {
+  const extendedSchema = extendSchema(SCHEMA_SOURCE);
+  const controller = new GqlEntityController(extendedSchema);
+
+  const source = codegen(controller, {}, 'javascript')
+    .replace(/^import .*\n\n/, '')
+    .replace(/export /g, '');
+  const { Space, Proposal } = new Function(
+    'Model',
+    `${source}\nreturn { Space, Proposal };`
+  )(Model);
+
+  describe('varchar length validation', () => {
+    it('should reject id longer than 256 characters', () => {
+      expect(() => new Space('x'.repeat(257), 'indexer')).toThrow(
+        'Value for Space.id exceeds 256 characters'
+      );
+    });
+
+    it('should reject values longer than 256 characters for String fields', () => {
+      const space = new Space('space-1', 'indexer');
+
+      expect(() => {
+        space.controller = 'x'.repeat(257);
+      }).toThrow('Value for Space.controller exceeds 256 characters');
+    });
+
+    it('should accept values up to 256 characters', () => {
+      const space = new Space('space-1', 'indexer');
+      space.controller = 'x'.repeat(256);
+
+      expect(space.controller).toHaveLength(256);
+    });
+
+    it('should count characters, not UTF-16 code units', () => {
+      const space = new Space('space-1', 'indexer');
+      const emojis = '🙂'.repeat(200);
+      space.controller = emojis;
+
+      expect(space.controller).toBe(emojis);
+    });
+
+    it('should accept null for nullable String fields', () => {
+      const space = new Space('space-1', 'indexer');
+      space.name = null;
+
+      expect(space.name).toBeNull();
+    });
+
+    it('should reject long values for nullable String fields', () => {
+      const space = new Space('space-1', 'indexer');
+
+      expect(() => {
+        space.name = 'x'.repeat(257);
+      }).toThrow('Value for Space.name exceeds 256 characters');
+    });
+
+    it('should reject long values for object reference fields', () => {
+      const proposal = new Proposal('proposal-1', 'indexer');
+
+      expect(() => {
+        proposal.space = 'x'.repeat(257);
+      }).toThrow('Value for Proposal.space exceeds 256 characters');
+    });
+
+    it('should not limit Text fields', () => {
+      const proposal = new Proposal('proposal-1', 'indexer');
+      const longText = 'x'.repeat(10000);
+      proposal.title = longText;
+
+      expect(proposal.title).toBe(longText);
+    });
+
+    it('should not limit list fields', () => {
+      const space = new Space('space-1', 'indexer');
+      const strategies = Array.from({ length: 100 }, (_, i) =>
+        `strategy-${i}`.repeat(30)
+      );
+      space.strategies = strategies;
+
+      expect(space.strategies).toEqual(strategies);
+    });
+  });
+
+  describe('NUL character validation', () => {
+    it('should reject id containing NUL character', () => {
+      expect(() => new Space('space\u0000-1', 'indexer')).toThrow(
+        'Value for Space.id contains a NUL character'
+      );
+    });
+
+    it('should reject NUL character in String fields', () => {
+      const space = new Space('space-1', 'indexer');
+
+      expect(() => {
+        space.controller = 'abc\u0000def';
+      }).toThrow('Value for Space.controller contains a NUL character');
+    });
+
+    it('should reject NUL character in Text fields', () => {
+      const proposal = new Proposal('proposal-1', 'indexer');
+
+      expect(() => {
+        proposal.title = 'abc\u0000def';
+      }).toThrow('Value for Proposal.title contains a NUL character');
+    });
+
+    it('should reject NUL character in list elements', () => {
+      const space = new Space('space-1', 'indexer');
+
+      expect(() => {
+        space.strategies = ['ok', 'bad\u0000'];
+      }).toThrow('Value for Space.strategies contains a NUL character');
+    });
   });
 });

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -1,21 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[` 1`] = `"'id' field for type Vote must be non nullable."`;
-
-exports[` 2`] = `"'id' field for type Vote is not a scalar type."`;
-
-exports[` 3`] = `"'id' field for type Participant is not a scalar type."`;
-
-exports[`GqlEntityController createEntityStores should work 1`] = `
-"drop table if exists \`votes\`;
-create table \`votes\` (\`uid\` char(36) default (lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6)))), \`block_range\` int8range not null, \`id\` integer not null, \`name\` varchar(256), \`authenticators\` json, \`big_number\` bigint, \`decimal\` float, \`big_decimal\` float, primary key (\`uid\`));
-create index \`votes_id_index\` on \`votes\` (\`id\`);
-create index \`votes_name_index\` on \`votes\` (\`name\`);
-create index \`votes_authenticators_index\` on \`votes\` (\`authenticators\`);
-create index \`votes_big_number_index\` on \`votes\` (\`big_number\`);
-create index \`votes_decimal_index\` on \`votes\` (\`decimal\`);
-create index \`votes_big_decimal_index\` on \`votes\` (\`big_decimal\`)"
-`;
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`GqlEntityController generateQueryFields should work 1`] = `
 "type Query {
@@ -60,6 +43,58 @@ input Vote_filter {
   authenticators_not: [String]
   authenticators_contains: [String]
   authenticators_not_contains: [String]
+}"
+`;
+
+exports[`GqlEntityController generateQueryFields should fail for non null object id 1`] = `"'id' field for type Vote must be non nullable."`;
+
+exports[`GqlEntityController generateQueryFields should fail for object id is not scalar type 1`] = `"'id' field for type Vote is not a scalar type."`;
+
+exports[`GqlEntityController generateQueryFields should fail for object id is not scalar type 2 1`] = `"'id' field for type Participant is not a scalar type."`;
+
+exports[`GqlEntityController createEntityStores should work 1`] = `
+"drop table if exists \`votes\`;
+create table \`votes\` (\`uid\` char(36) default (lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6)))), \`block_range\` int8range not null, \`id\` integer not null, \`name\` varchar(256), \`authenticators\` json, \`big_number\` bigint, \`decimal\` float, \`big_decimal\` float, primary key (\`uid\`));
+create index \`votes_id_index\` on \`votes\` (\`id\`);
+create index \`votes_name_index\` on \`votes\` (\`name\`);
+create index \`votes_big_number_index\` on \`votes\` (\`big_number\`);
+create index \`votes_decimal_index\` on \`votes\` (\`decimal\`);
+create index \`votes_big_decimal_index\` on \`votes\` (\`big_decimal\`)"
+`;
+
+exports[`GqlEntityController generateSampleQuery should return correct query sample for first and only entity 1`] = `
+"
+# Welcome to Checkpoint. Try running the below example query from
+# your defined entity.
+    
+query {
+    votes (first: 10) {
+        id
+        name
+        created_at
+    }
+}"
+`;
+
+exports[`GqlEntityController generateSampleQuery should return correct query sample for nested objects 1`] = `
+"
+# Welcome to Checkpoint. Try running the below example query from
+# your defined entity.
+    
+query {
+    votes (first: 10) {
+        id
+        name
+        poster {
+            id
+            name
+            venue {
+                id
+                location
+            }
+        }
+        created_at
+    }
 }"
 `;
 
@@ -196,45 +231,3 @@ input _Checkpoint_filter {
   contract_address_not_in: [String]
 }"
 `;
-
-exports[`GqlEntityController generateSampleQuery should return correct query sample for first and only entity 1`] = `
-"
-# Welcome to Checkpoint. Try running the below example query from
-# your defined entity.
-    
-query {
-    votes (first: 10) {
-        id
-        name
-        created_at
-    }
-}"
-`;
-
-exports[`GqlEntityController generateSampleQuery should return correct query sample for nested objects 1`] = `
-"
-# Welcome to Checkpoint. Try running the below example query from
-# your defined entity.
-    
-query {
-    votes (first: 10) {
-        id
-        name
-        poster {
-            id
-            name
-            venue {
-                id
-                location
-            }
-        }
-        created_at
-    }
-}"
-`;
-
-exports[`GqlEntityController generateQueryFields should fail for non null object id 1`] = `"'id' field for type Vote must be non nullable."`;
-
-exports[`GqlEntityController generateQueryFields should fail for object id is not scalar type 1`] = `"'id' field for type Vote is not a scalar type."`;
-
-exports[`GqlEntityController generateQueryFields should fail for object id is not scalar type 2 1`] = `"'id' field for type Participant is not a scalar type."`;


### PR DESCRIPTION
SX API in some cases writes bad data into ORM. This previously was handled as failures would be surfaced on `.save` call.
But now as writes are buffered this becomes an issue when writes are flushed and at this point it's not possible to handle that at writer level.

To avoid that we add two edge case handling in ORM setter:
1. `varchar` overflows 256 characters.
2. `varchar` or `string` based value contains NUL byte.

When writer tries to set such value it will throw in-place where writer can react to it.

There was another issue with `jsonb` index size. This index isn't actually used for the queries we use (not applicable for operators we use), so we simply remove it.